### PR TITLE
Add digiline rules to inactive reactor

### DIFF
--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -431,9 +431,13 @@ minetest.register_node("technic:hv_nuclear_reactor_core", {
 
 	-- digiline interface
 	digiline = {
-		receptor = {action = function() end},
+		receptor = {
+			rules = technic.digilines.rules,
+			action = function() end,
+		},
 		effector = {
-			action = digiline_def
+			rules = technic.digilines.rules,
+			action = digiline_def,
 		},
 	},
 


### PR DESCRIPTION
This allows the reactor to be started via digiline if the connection is to the bottom or top.

The previous commit 28536514271b1c14928a72e15eca701858f0c203 only added the rules for active reactors.