### PR TITLE
Add digiline interface to power monitor and make it more useful

### DIFF
--- a/technic/doc/digilines.md
+++ b/technic/doc/digilines.md
@@ -38,6 +38,12 @@ if event.type == "digiline" and event.channel == "switch" then
 end
 ```
 
+## Power monitor
+The commands:
+- `"get"`: The power monitor sends back information about the attached network
+  - `"supply"`, `"demand"` and `"lag"`: Same as switching station
+  - `"battery_count"`, `"battery_charge"` and `"battery_charge_max"`: Totaled information about the attached batteries.
+
 
 ## Supply Converter
 You can send the following to it:

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -240,6 +240,7 @@ function technic.register_battery_box(data)
 		meta:set_int(tier.."_EU_supply",
 				math.min(data.discharge_rate, current_charge))
 			meta:set_int("internal_EU_charge", current_charge)
+		meta:set_int("internal_EU_charge_max", max_charge)
 
 		-- Select node textures
 		local charge_count = math.ceil((current_charge / max_charge) * 8)

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -306,9 +306,16 @@ technic.switching_station_run = function(pos)
 	local charge_total = 0
 	local battery_count = 0
 
+	local BA_charge = 0
+	local BA_charge_max = 0
+
 	for n, pos1 in pairs(BA_nodes) do
 		meta1 = minetest.get_meta(pos1)
 		local charge = meta1:get_int("internal_EU_charge")
+		local charge_max = meta1:get_int("internal_EU_charge_max")
+
+		BA_charge = BA_charge + charge
+		BA_charge_max = BA_charge_max + charge_max
 
 		if (meta1:get_int(eu_demand_str) ~= 0) then
 			charge_total = charge_total + charge
@@ -378,6 +385,9 @@ technic.switching_station_run = function(pos)
 	-- Data that will be used by the power monitor
 	meta:set_int("supply",PR_eu_supply)
 	meta:set_int("demand",RE_eu_demand)
+	meta:set_int("battery_count",#BA_nodes)
+	meta:set_int("battery_charge",BA_charge)
+	meta:set_int("battery_charge_max",BA_charge_max)
 
 	-- If the PR supply is enough for the RE demand supply them all
 	if PR_eu_supply >= RE_eu_demand then


### PR DESCRIPTION
The power monitor can now be queried for information about the network. They are retrieved from the associated switching station.
Also export information about the attached batteries.


This allows getting information about the network from any location without using digiline hv cables everywhere and thus creating unnecessary large digiline networks.