### PR TITLE
Fix server crash on anchor placement

### DIFF
--- a/technic/machines/other/anchor.lua
+++ b/technic/machines/other/anchor.lua
@@ -114,7 +114,7 @@ minetest.register_node("technic:admin_anchor", {
 			end,
 			action_off = function(pos)
 				local meta = minetest.get_meta(pos)
-				forceload_off(pos, meta)
+				forceload_off(meta)
 			end
 		}
 	}


### PR DESCRIPTION
In b0e45d401257e6cf79ff648d21ea7309fb11f44c the method signature for `forceload_off(meta)` was mixed up with `forceload_on(pos, meta)` leading to a server crash when an anchor is placed (probably also when mesecons is turned off).

Server crash log:

```
ERROR[Main]: ServerError: AsyncErr: environment_Step: Runtime error from mod 'player_api' in callback environment_Step(): ....minetest/mods/technic/technic/machines/other/anchor.lua:27: attempt to call method 'get_string' (a nil value)
ERROR[Main]: stack traceback:
ERROR[Main]:    ....minetest/mods/technic/technic/machines/other/anchor.lua:27: in function 'currently_forceloaded_positions'
ERROR[Main]:    ....minetest/mods/technic/technic/machines/other/anchor.lua:32: in function 'forceload_off'
ERROR[Main]:    ....minetest/mods/technic/technic/machines/other/anchor.lua:117: in function 'action_off'
ERROR[Main]:    ....minetest/mods/mesecons/mesecons/internal.lua:213: in function <....minetest/mods/mesecons/mesecons/internal.lua:206>
ERROR[Main]:    ....minetest/mods/mesecons/mesecons/actionqueue.lua:137: in function 'old_execute'
ERROR[Main]:    ....minetest/mods/mesecons_debug/overrides.lua:7: in function 'execute'
ERROR[Main]:    ....minetest/mods/mesecons/mesecons/actionqueue.lua:111: in function <....minetest/mods/mesecons/mesecons/actionqueue.lua:73>
ERROR[Main]:    ....minetest/builtin/game/register.lua:429: in function <....minetest/builtin/game/register.lua:413>
ERROR[Main]: stack traceback:
```