### PR TITLE
Fix quarry rotation

### DIFF
--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -281,6 +281,20 @@ minetest.register_node("technic:quarry", {
 		reset_quarry(pos)
 		set_quarry_status(pos)
 	end,
+	on_rotate = function(pos, node, player, click, new_param2)
+		local meta = minetest.get_meta(pos)
+		if meta:get_int("enabled") == 1 then
+			return false
+		end
+
+		-- only allow rotation around y-axis
+		node.param2 = new_param2 % 4
+
+		minetest.swap_node(pos, node)
+		reset_quarry(pos)
+		set_quarry_status(pos)
+		return true
+	end,
 	after_place_node = function(pos, placer, itemstack)
 		minetest.get_meta(pos):set_string("owner", placer:get_player_name())
 		pipeworks.scan_for_tube_objects(pos)


### PR DESCRIPTION
Previously the model was rotated but the dig position of the quarry was not updated.
If the player did not restart the quarry through the formspec, it dug at the previous location.

This fix adds an on_rotate handler that resets the quarry after rotation. The quarry must be disabled to be rotated and only rotation around the y-axis is possible.