### PR TITLE
Add digiline interface to quarry

### DIFF
--- a/technic/doc/digilines.md
+++ b/technic/doc/digilines.md
@@ -108,3 +108,25 @@ The commands:
 - `"start"`: Tries to start the reactor, `"Start successful"` is sent back on success, `"Error"` if something is wrong.
 
 If the automatic start is enabled, it will always send `"fuel used"` when it uses fuel.
+
+
+## Quarry
+You should send a table to it containing the `command` and for some commands the `value` field.
+Some strings will automatically be converted to tables:
+- `"get"` :arrow_right: `{command = "get"}`
+- `"on"` :arrow_right: `{command = "on"}`
+- `"off"` :arrow_right: `{command = "off"}`
+- `"restart` :arrow_right: `{command = "restart"}`
+- `"radius "..value` :arrow_right: `{command = "radius", value = value}`
+
+The commands:
+- `"get"`: The forcefield emitter sends back a table containing:
+  - `"enabled"`: `0` is off, `1` is on.
+  - `"radius"`
+  - `"finished"`
+  - `"dug_nodes"`
+  - `"dig_level"`: A negative value means above the quarry, a positive value means below.
+- `"on"`: Activate the quarry.
+- `"off"`: Deactivate the quarry.
+- `"restart"`: Restart the quarry.
+- `"radius"`: Set the radius to `value` and restart the quarry if the radius changed.


### PR DESCRIPTION
This adds a digiline interface that can be used to start, stop and restart, set the radius and get the current status.