### PR TITLE
fix: touch disabled switching stations

### DIFF
--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -192,6 +192,7 @@ local get_network = function(sw_pos, pos1, tier)
 			local meta = minetest.get_meta(pos)
 			meta:set_int("active", 0)
 			meta:set_string("active_pos", minetest.serialize(sw_pos))
+			meta:set_int(tier.."_EU_timeout", 2) -- Touch node
 		end
 		return cached.PR_nodes, cached.BA_nodes, cached.RE_nodes
 	end


### PR DESCRIPTION
Otherwise the "switching station reenable abm" https://github.com/mt-mods/technic/blob/6a9cf6da27afd4f33283934507085a00b6cbda88/technic/machines/switching_station.lua#L514-L528 will reenable the disabled switching station at its next run.