### PR TITLE
Switching check

### DIFF
--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -10,13 +10,12 @@ local reset_overloaded = function(network_id)
 	local remaining = math.max(0, overloaded_networks[network_id] - minetest.get_us_time())
 	if remaining == 0 then
 		-- Clear cache, remove overload and restart network
-		print("Removing overloaded network and clearing cache")
 		overloaded_networks[network_id] = nil
 		technic.networks[network_id] = nil
 	end
+	-- Returns 0 when network reset or remaining time if reset timer has not expired yet
 	return remaining
 end
-
 
 local switch_max_range = tonumber(minetest.settings:get("technic.switch_max_range") or "256")
 


### PR DESCRIPTION
### What:
Overload mechanism mostly for mitigating cheats:

- technic run frequency multiplication, multiple switching stations running single machine.
- getting output to multiple networks from single generator, like total 25kEU from single HV solar.
- drawing power from single battery box to multiple networks.
- basically should prevent all cheats utilizing machine / generator connections to multiple networks.

### What is not prevented:

- free energy battery box as long as it is connected to single network only.

### Possible bad things:

* Neighbor network cache is cleared when overload happens, also cache is cleared during overload reset for network that initiated checks.
This means that after overload is cleared network cache will get rebuilt (expensive operation) and if it fails checks again then cache will be cleared again. Overload reset time is 20 seconds by default, so every 20 seconds at least single network cache will be rebuilt until problem with network is fixed.

* Behavior is still a bit undefined when network contains more than 2 switching station firing ABM events, during tests everything worked better that what I expected even with networks containing 5-10 switching stations. All networks settled after some time, ones with many switching stations took multiple overload/reset cycles which is expected because of how switch reactivation works.

* Network will be invalid after switching station is moved to another location while still connected to network, this causes single overload/reset cycle (chache rebuild etc.) before it settles. Problem is probably most annoying with jumpdrive mod / space ships where it causes overload after every jump.

### Things I checked / verified working during testing:

Tested @ pandorabox servers

- SwissalpS whatever-submoonthing, stuff works correctly. Things duplicating energy output are disabled correctly.
- H.A.C.C. fired up most of it and everything did work correctly.
- JackB MoonX things and earth workshop, legit setups and everything works correctly.
- Huhhila's space ship / jumpable quarry base things, we did some testing around here. Multiple systems and everything seemed to work correctly (legit networks, multiple switching stations and disabling cheat networks)
- HiFi City workshop and centrifuge arrays. Also many other setups near HiFi city. Everything works correctly. Took multiple reset cycles before workshop networks settled (a lot of switching station in small area).
- SX Cargo Hauler multiple switching stations, took single reset cycle and after that everything works correctly. Also quarry drones (utilizing free energy bug).
- SX Buggy mini ship that draws 10kEU from single HV solar, correctly disabled and wont get any output.
- SX LavaFalls LV -> MV -> HV setup, works correctly.
- Various other setups I found while running around during testing, no problems found after initial network resets.