### PR TITLE
Switching updates

### DIFF
--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -490,11 +490,10 @@ minetest.register_node("technic:hv_nuclear_reactor_core_active", {
 		timer:start(1)
         end,
 	on_timer = function(pos, node)
-		local meta = minetest.get_meta(pos)
-
 		-- Connected back?
-		if meta:get_int("HV_EU_timeout") > 0 then return false end
+		if technic.get_timeout("HV", pos) > 0 then return false end
 
+		local meta = minetest.get_meta(pos)
 		local burn_time = meta:get_int("burn_time") or 0
 
 		if burn_time >= burn_ticks or burn_time == 0 then

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -101,7 +101,7 @@ minetest.register_abm({
 		local sw_pos = get_swpos(pos)
 		local timeout = 0
 		for tier in pairs(technic.machines) do
-			timeout = math.max(meta:get_int(tier.."_EU_timeout"),timeout)
+			timeout = math.max(technic.get_timeout(tier, pos),timeout)
 		end
 		if timeout > 0 and sw_pos then
 			local sw_meta = minetest.get_meta(sw_pos)

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -6,13 +6,38 @@ local S = technic.getter
 
 local cable_entry = "^technic_cable_connection_overlay.png"
 
+-- Get registered cable or nil, returns nil if area is not loaded
+local function get_cable(pos)
+	local node = minetest.get_node_or_nil(pos)
+	return (node and technic.get_cable_tier(node.name)) and node
+end
+
+-- return the position of connected cable or nil
+local function get_connected_cable_network(pos)
+	local param2 = minetest.get_node(pos).param2
+	-- should probably also work sideways or upside down but for now it wont
+	if param2 > 3 then return end
+	-- Below?
+	local checkpos = {x=pos.x,y=pos.y-1,z=pos.z}
+	local network_id = get_cable(checkpos) and technic.pos2network(checkpos)
+	if network_id then
+		return network_id
+	end
+	-- Behind?
+	checkpos = vector.add(minetest.facedir_to_dir(param2),pos)
+	network_id = get_cable(checkpos) and technic.pos2network(checkpos)
+	if network_id then
+		return network_id
+	end
+end
+
 -- return the position of the associated switching station or nil
 local function get_swpos(pos)
-	local network_hash = technic.cables[minetest.hash_node_position(pos)]
-	local network = network_hash and minetest.get_position_from_hash(network_hash)
-	local swpos = network and {x=network.x,y=network.y+1,z=network.z}
+	local network_id = get_connected_cable_network(pos)
+	local network = network_id and technic.networks[network_id]
+	local swpos = network and technic.network2sw_pos(network_id)
 	local is_powermonitor = swpos and minetest.get_node(swpos).name == "technic:switching_station"
-	return is_powermonitor and swpos or nil
+	return (is_powermonitor and network.all_nodes[network_id]) and swpos
 end
 
 minetest.register_craft({
@@ -99,11 +124,7 @@ minetest.register_abm({
 	action = function(pos, node, active_object_count, active_object_count_wider)
 		local meta = minetest.get_meta(pos)
 		local sw_pos = get_swpos(pos)
-		local timeout = 0
-		for tier in pairs(technic.machines) do
-			timeout = math.max(technic.get_timeout(tier, pos),timeout)
-		end
-		if timeout > 0 and sw_pos then
+		if sw_pos then
 			local sw_meta = minetest.get_meta(sw_pos)
 			local supply = sw_meta:get_int("supply")
 			local demand = sw_meta:get_int("demand")
@@ -115,9 +136,3 @@ minetest.register_abm({
 		end
 	end,
 })
-
-for tier in pairs(technic.machines) do
-	-- RE in order to use the "timeout" functions, although it consumes 0 power
-	technic.register_machine(tier, "technic:power_monitor", "RE")
-end
-

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -60,10 +60,11 @@ local function clear_networks(pos)
 
 				-- Actually add it to the (cached) network
 				-- This is similar to check_node_subp
-				technic.cables[minetest.hash_node_position(pos)] = network_id
+				local pos_hash = minetest.hash_node_position(pos)
+				technic.cables[pos_hash] = network_id
 				pos.visited = 1
 				if technic.is_tier_cable(name, tier) then
-					table.insert(network.all_nodes,pos)
+					network.all_nodes[pos_hash] = pos
 				elseif technic.machines[tier][node.name] then
 					if     technic.machines[tier][node.name] == technic.producer then
 						table.insert(network.PR_nodes,pos)

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -38,7 +38,6 @@ end
 
 local function clear_networks(pos)
 	local node = minetest.get_node(pos)
-	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"
 	local positions = check_connections(pos)
 	if #positions < 1 then return end
@@ -66,7 +65,6 @@ local function clear_networks(pos)
 				if technic.is_tier_cable(name, tier) then
 					table.insert(network.all_nodes,pos)
 				elseif technic.machines[tier][node.name] then
-					meta:set_string(tier.."_network",minetest.pos_to_string(sw_pos))
 					if     technic.machines[tier][node.name] == technic.producer then
 						table.insert(network.PR_nodes,pos)
 					elseif technic.machines[tier][node.name] == technic.receiver then

--- a/technic/machines/register/generator.lua
+++ b/technic/machines/register/generator.lua
@@ -206,11 +206,11 @@ function technic.register_generator(data)
 			timer:start(1)
 		end,
 		on_timer = function(pos, node)
+			-- Connected back?
+			if technic.get_timeout(tier, pos) > 0 then return false end
+
 			local meta = minetest.get_meta(pos)
 			local node = minetest.get_node(pos)
-
-			-- Connected back?
-			if meta:get_int(tier.."_EU_timeout") > 0 then return false end
 
 			local burn_time = meta:get_int("burn_time") or 0
 

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -66,7 +66,17 @@ minetest.register_node("technic:switching_station",{
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", S("Switching Station"))
-		meta:set_string("active", 1)
+		local network_id = technic.sw_pos2network(pos)
+		local net_sw_pos = network_id and technic.network2sw_pos(network_id)
+		local net_sw_node = net_sw_pos and minetest.get_node(net_sw_pos)
+		if net_sw_node and net_sw_node.name == "technic:switching_station" then
+			-- There's already network with same id, check if it already has active switching station
+			-- set active to 0 for this switch if there's already another active
+			local net_sw_meta = minetest.get_meta(net_sw_pos)
+			meta:set_string("active", net_sw_meta:get_int("active") == 1 and 0 or 1)
+		else
+			meta:set_string("active", 1)
+		end
 		meta:set_string("channel", "switching_station"..minetest.pos_to_string(pos))
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 		local poshash = minetest.hash_node_position(pos)
@@ -214,6 +224,10 @@ local function traverse_network(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_node
 	for i, cur_pos in pairs(positions) do
 		check_node_subp(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_nodes, cur_pos, machines, tier, sw_pos, i == 3, network_id, queue)
 	end
+end
+
+function technic.sw_pos2network(pos)
+	return pos and technic.cables[minetest.hash_node_position({x=pos.x,y=pos.y-1,z=pos.z})]
 end
 
 function technic.pos2network(pos)

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -214,26 +214,26 @@ local function traverse_network(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_node
 	return true
 end
 
-technic.node_timeout = {}
+local node_timeout = {}
 
 technic.pos2network = function(pos)
 	return technic.cables[minetest.hash_node_position(pos)]
 end
 
 technic.get_timeout = function(tier, pos)
-	if technic.node_timeout[tier] == nil then
+	if node_timeout[tier] == nil then
 		-- it is normal that some multi tier nodes always drop here when checking all LV, MV and HV tiers
 		return 0
 	end
-	return technic.node_timeout[tier][minetest.hash_node_position(pos)] or 0
+	return node_timeout[tier][minetest.hash_node_position(pos)] or 0
 end
 
 technic.touch_node = function(tier, pos, timeout)
-	if technic.node_timeout[tier] == nil then
+	if node_timeout[tier] == nil then
 		-- this should get built up during registration
-		technic.node_timeout[tier] = {}
+		node_timeout[tier] = {}
 	end
-	technic.node_timeout[tier][minetest.hash_node_position(pos)] = timeout or 2
+	node_timeout[tier][minetest.hash_node_position(pos)] = timeout or 2
 end
 
 local function touch_nodes(list, tier)


### PR DESCRIPTION
## NEEDS SOME TESTING

So I've not tested this much, just basics with very simple stuff.

Reduces metadata use. Removes completely following metadata keys:
* LV_EU_timeout
* MV_EU_timeout
* HV_EU_timeout
* LV_network
* MV_network
* HV_network

Overload reset clean up cable network.
~Overload causes early exit from network traversal.~ Reverted that, should be able to enable again now that cable cache is also cleaned up but better to not include that yet.

Fixes #76 
Partially fixes #77 