### PR TITLE
Add compatibility hack for digtron

### DIFF
--- a/technic/machines/compat/digtron.lua
+++ b/technic/machines/compat/digtron.lua
@@ -1,0 +1,25 @@
+--
+-- Compatibility hacks for digtron to work well with technic plus new network system
+--
+-- More information:
+-- https://github.com/mt-mods/technic/issues/100
+--
+
+local function power_connector_compat()
+	local digtron_technic_run = minetest.registered_nodes["digtron:power_connector"].technic_run
+	minetest.override_item("digtron:power_connector",{
+		technic_run = function(pos, node)
+			local network_id = technic.pos2network(pos)
+			local sw_pos = network_id and technic.network2sw_pos(network_id)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("HV_network", sw_pos and minetest.pos_to_string(sw_pos) or "")
+			return digtron_technic_run(pos, node)
+		end,
+	})
+end
+
+minetest.register_on_mods_loaded(function()
+	if minetest.registered_nodes["digtron:power_connector"] then
+		power_connector_compat()
+	end
+end)

--- a/technic/machines/compat/digtron.lua
+++ b/technic/machines/compat/digtron.lua
@@ -9,8 +9,9 @@ local function power_connector_compat()
 	local digtron_technic_run = minetest.registered_nodes["digtron:power_connector"].technic_run
 	minetest.override_item("digtron:power_connector",{
 		technic_run = function(pos, node)
-			local network_id = technic.pos2network(pos)
-			local sw_pos = network_id and technic.network2sw_pos(network_id)
+			local network_id = technic.cables[minetest.hash_node_position(pos)]
+			local sw_pos = network_id and minetest.get_position_from_hash(network_id)
+			if sw_pos then sw_pos.y = sw_pos.y + 1 end
 			local meta = minetest.get_meta(pos)
 			meta:set_string("HV_network", sw_pos and minetest.pos_to_string(sw_pos) or "")
 			return digtron_technic_run(pos, node)

--- a/technic/machines/init.lua
+++ b/technic/machines/init.lua
@@ -28,3 +28,6 @@ dofile(path.."/power_monitor.lua")
 dofile(path.."/supply_converter.lua")
 
 dofile(path.."/other/init.lua")
+
+-- https://github.com/mt-mods/technic/issues/100
+dofile(path.."/compat/digtron.lua")

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -604,8 +604,8 @@ end
 minetest.register_abm({
 	label = "Machines: timeout check",
 	nodenames = {"group:technic_machine"},
-	interval   = 1.9,
-	chance     = 3,
+	interval   = 1,
+	chance     = 1,
 	action = function(pos, node, active_object_count, active_object_count_wider)
 		for tier, machines in pairs(technic.machines) do
 			if machines[node.name] and switching_station_timeout_count(pos, tier) then


### PR DESCRIPTION
Closes #100 
See #100 for more information and possible other options how this could be handled.

I've checked few other mods that add technic machines and did not find similar problems so this might be fine here. Digtron wont actually need that metadata value for anything, for some reason it just checks if it is there.

Not sure about reason behind this one but probably it is to verify that there really is network connected but that should not be needed because machine deactivation ABM should handle this already like it does for other machines and generators.

### Why wont fix:
There's been nasty bug with HV power connector long before any network updates.

> digtron keeps digging for a while after having left cable.

There's no simple fix for that without patching problem in Digtron code, merging this PR makes Digtron power connector work but allows using Digtron without actual power network. If ABM that should disable detached machines wont get executed Digtron will continue as long as it can, that is until it hits lava pool, loses traction, hits ignore nodes or machine timeout ABM executes.

### How this can possibly be fixed without touching Digtron code:
It might be possible to fix this without changing Digtron code if Digtron calls on_construct or on_place when components is moved along with digtron.
If it does so then it might be possible to clear metadata if there's no network connection anymore but this might not work as Digtron does somehow restore previous meta after moving components, also this would be another hacky external patch while Digtron should be able to handle this.
Fixing with callbacks also depend on how Digtron actually restores metadata after moving components.