### PR TITLE
Battery handling, machine loop optimization

### DIFF
--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -189,14 +189,8 @@ function technic.register_battery_box(data)
 			"listring[current_player;main]"
 	end
 
-	local run = function(pos, node)
-		local below = minetest.get_node({x=pos.x, y=pos.y-1, z=pos.z})
-		local meta           = minetest.get_meta(pos)
-
-		if not technic.is_tier_cable(below.name, tier) then
-			meta:set_string("infotext", S("%s Battery Box Has No Network"):format(tier))
-			return
-		end
+	local run = function(pos, node, _, network)
+		local meta  = minetest.get_meta(pos)
 
 		local eu_input       = meta:get_int(tier.."_EU_input")
 		local current_charge = meta:get_int("internal_EU_charge")


### PR DESCRIPTION
Requires some testing and opinions.

* Battery box formspec updated, power meter wont update while formspec is open.
* Default digiline channel is empty and channel field moved to main form, second formspec removed.
* Stack splitting removed from battery box, stacking items that can be charged without taking whole stack capacity into account is cheating anyway. Also I've not yet seen stackable rechargeable items...
* Battery box node swapping / texture update done with nodetimer instead of globalstep, reduces a lot of node swapping (every second in active network vs every 2 seconds in active area).
* Optimized technic machine run loop.
* Getting smaller pull requests merged more often is better for quality and development speed.

So next thing would be to find problems in this pr and then continue with things not yet done, this is not enough to close any of issues alone.