### PR TITLE
add minetest.get_current_modname() to fixture

### DIFF
--- a/technic/spec/fixtures/minetest.lua
+++ b/technic/spec/fixtures/minetest.lua
@@ -109,6 +109,7 @@ _G.minetest.get_node = function(pos)
 end
 
 _G.minetest.get_modpath = function(...) return "./unit_test_modpath" end
+_G.minetest.get_current_modname = function() return "technic" end
 
 _G.minetest.get_pointed_thing_position = dummy_coords
 


### PR DESCRIPTION
this adds `minetest.get_current_modname()` to the fixture
It just returns "technic" in this case

Should fix the test-errors from #115
 
@S-S-X did i do this the right way?