### PR TITLE
delete pull bot config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,8 +1,0 @@
-version: "1"
-rules:
-  - base: upstream
-    upstream: minetest-mods:master
-    mergeMethod: hardreset
-  - base: master
-    upstream: minetest-mods:master
-    mergeMethod: merge


### PR DESCRIPTION
This disables the pull bot that fetches upstream commits and tries to merge them (#4 , #7 , #9, #17, #19, etc)
In light of the recent activity and the merge-conflicts from the bot i don't think that thing is needed anymore.

Opinions?
Merging this in a few days if there are no objections...

closes #89 