### PR TITLE
Remove channel generators, switch nuclear reactor remote_channel to channel

### DIFF
--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -279,7 +279,7 @@ local function run(pos, node)
 		if has_digilines and meta:get_int("HV_EU_supply") == power_supply then
 			digilines.receptor_send(pos, technic.digilines.rules,
 				-- TODO: Remove "remote_channel" and use de facto standard "channel"
-				meta:get("channel") or meta:get_string("remote_channel"),
+				meta:get("remote_channel") or meta:get_string("channel"),
 				{
 					command = "fuel_used",
 					pos = pos
@@ -345,7 +345,7 @@ local digiline_def = function(pos, _, channel, msg)
 	local meta = minetest.get_meta(pos)
 	if meta:get_string("enable_digiline") ~= "true" or
 			-- TODO: Remove "remote_channel" and use de facto standard "channel"
-			channel ~= meta:get("channel") or meta:get_string("remote_channel") then
+			channel ~= meta:get("remote_channel") or meta:get_string("channel") then
 		return
 	end
 	-- Convert string messages to tables:

--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -315,10 +315,10 @@ local nuclear_reactor_receive_fields = function(pos, formname, fields, sender)
 	end
 	local meta = minetest.get_meta(pos)
 	local update_formspec = false
-	if fields.channel then
+	if fields.channel or fields.remote_channel then
 		-- TODO: Remove "remote_channel" and use de facto standard "channel"
 		meta:set_string("remote_channel", "")
-		meta:set_string("channel", fields.channel)
+		meta:set_string("channel", fields.channel or fields.remote_channel)
 	end
 	if fields.start then
 		local b = start_reactor(pos, meta)

--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -48,7 +48,7 @@ local function make_reactor_formspec(meta)
 	end
 	return f..
 		"button_exit[4.6,3.69;2,1;save;Save]"..
-		"field[1,4;4,1;remote_channel;Digiline Remote Channel;${remote_channel}]"
+		"field[1,4;4,1;channel;Digiline Remote Channel;${channel}]"
 end
 
 local SS_OFF = 0
@@ -277,10 +277,14 @@ local function run(pos, node)
 	local burn_time = meta:get_int("burn_time") or 0
 	if burn_time >= burn_ticks or burn_time == 0 then
 		if has_digilines and meta:get_int("HV_EU_supply") == power_supply then
-			digilines.receptor_send(pos, technic.digilines.rules, meta:get_string("remote_channel"), {
+			digilines.receptor_send(pos, technic.digilines.rules,
+				-- TODO: Remove "remote_channel" and use de facto standard "channel"
+				meta:get("channel") or meta:get_string("remote_channel"),
+				{
 					command = "fuel_used",
 					pos = pos
-			})
+				}
+			)
 		end
 		if meta:get_string("autostart") == "true" then
 			if start_reactor(pos, meta) then
@@ -311,8 +315,10 @@ local nuclear_reactor_receive_fields = function(pos, formname, fields, sender)
 	end
 	local meta = minetest.get_meta(pos)
 	local update_formspec = false
-	if fields.remote_channel then
-		meta:set_string("remote_channel", fields.remote_channel)
+	if fields.channel then
+		-- TODO: Remove "remote_channel" and use de facto standard "channel"
+		meta:set_string("remote_channel", "")
+		meta:set_string("channel", fields.channel)
 	end
 	if fields.start then
 		local b = start_reactor(pos, meta)
@@ -338,7 +344,8 @@ end
 local digiline_def = function(pos, _, channel, msg)
 	local meta = minetest.get_meta(pos)
 	if meta:get_string("enable_digiline") ~= "true" or
-			channel ~= meta:get_string("remote_channel") then
+			-- TODO: Remove "remote_channel" and use de facto standard "channel"
+			channel ~= meta:get("channel") or meta:get_string("remote_channel") then
 		return
 	end
 	-- Convert string messages to tables:
@@ -421,10 +428,6 @@ minetest.register_node("technic:hv_nuclear_reactor_core", {
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", reactor_desc)
 		meta:set_string("formspec", make_reactor_formspec(meta))
-		if has_digilines then
-			meta:set_string("remote_channel",
-					"nuclear_reactor"..minetest.pos_to_string(pos))
-		end
 		local inv = meta:get_inventory()
 		inv:set_size("src", 6)
 	end,

--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -48,7 +48,7 @@ local function make_reactor_formspec(meta)
 	end
 	return f..
 		"button_exit[4.6,3.69;2,1;save;Save]"..
-		"field[1,4;4,1;channel;Digiline Remote Channel;${channel}]"
+		"field[1,4;4,1;channel;Digiline Channel;${channel}]"
 end
 
 local SS_OFF = 0
@@ -279,7 +279,7 @@ local function run(pos, node)
 		if has_digilines and meta:get_int("HV_EU_supply") == power_supply then
 			digilines.receptor_send(pos, technic.digilines.rules,
 				-- TODO: Remove "remote_channel" and use de facto standard "channel"
-				meta:get("remote_channel") or meta:get_string("channel"),
+				meta:get("channel") or meta:get_string("remote_channel"),
 				{
 					command = "fuel_used",
 					pos = pos
@@ -317,7 +317,7 @@ local nuclear_reactor_receive_fields = function(pos, formname, fields, sender)
 	local update_formspec = false
 	if fields.channel or fields.remote_channel then
 		-- TODO: Remove "remote_channel" and use de facto standard "channel"
-		meta:set_string("remote_channel", "")
+		meta:set_string("remote_channel", fields.channel or fields.remote_channel)
 		meta:set_string("channel", fields.channel or fields.remote_channel)
 	end
 	if fields.start then
@@ -345,7 +345,7 @@ local digiline_def = function(pos, _, channel, msg)
 	local meta = minetest.get_meta(pos)
 	if meta:get_string("enable_digiline") ~= "true" or
 			-- TODO: Remove "remote_channel" and use de facto standard "channel"
-			channel ~= meta:get("remote_channel") or meta:get_string("channel") then
+			channel ~= meta:get("channel") or meta:get_string("remote_channel") then
 		return
 	end
 	-- Convert string messages to tables:

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -65,7 +65,6 @@ minetest.register_node("technic:power_monitor",{
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", S("Power Monitor"))
-		meta:set_string("channel", "power_monitor"..minetest.pos_to_string(pos))
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -185,9 +185,6 @@ minetest.register_node("technic:supply_converter", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", S("Supply Converter"))
-		if digilines_path then
-			meta:set_string("channel", "supply_converter"..minetest.pos_to_string(pos))
-		end
 		meta:set_int("power", 10000)
 		meta:set_int("enabled", 1)
 		meta:set_int("mesecon_mode", 0)

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -48,7 +48,6 @@ minetest.register_node("technic:switching_station",{
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", S("Switching Station"))
-		meta:set_string("channel", "switching_station"..minetest.pos_to_string(pos))
 		meta:set_string("formspec", "field[channel;Channel;${channel}]")
 		start_network(pos)
 	end,


### PR DESCRIPTION
Removes digiline channel name generators.

Changed nuclear reactor digiline channel meta key from "remote_channel" _(never seen this used anywhere for digiline channels)_ to de facto standard channel meta key "channel".

Metadata is only updated when channel is actually set through formspec, always tries "remote_channel" first and use "channel" only if "remote_channel" is not set.
This is to keep maximum compatibility, LBM should be used to actually update channel metadata key everywhere.

For more information see #112 