### PR TITLE
add mtinfo generate workflow

### DIFF
--- a/.github/workflows/mtinfo.yml
+++ b/.github/workflows/mtinfo.yml
@@ -1,0 +1,21 @@
+name: mtinfo
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: generate
+      run: ./generate-mtinfo.sh
+
+    - name: deploy
+      if: github.ref == 'refs/heads/master'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./output

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A mod for [minetest](http://www.minetest.net)
 ![integration-test](https://github.com/mt-mods/technic/workflows/integration-test/badge.svg)
 ![luacheck](https://github.com/mt-mods/technic/workflows/luacheck/badge.svg)
 ![mineunit](https://github.com/mt-mods/technic/workflows/mineunit/badge.svg)
+![mtinfo](https://github.com/mt-mods/technic/workflows/mtinfo/badge.svg)
 ![](https://byob.yarr.is/mt-mods/technic/coverage)
 
 [![License](https://img.shields.io/badge/license-LGPLv2.0%2B-purple.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html)
@@ -38,6 +39,7 @@ their own manuals:
 * [Pipeworks Documentation](https://gitlab.com/VanessaE/pipeworks/-/wikis/home)
 * [Moreores Forum Post](https://forum.minetest.net/viewtopic.php?t=549)
 * [Basic materials Repository](https://gitlab.com/VanessaE/basic_materials)
+* [mtinfo generated documentation](https://mt-mods.github.io/technic/#/mods/technic/items)
 
 Recipes for constructable items in technic are generally not guessable,
 and are also not specifically documented here.  You should use a

--- a/generate-mtinfo.sh
+++ b/generate-mtinfo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # prepare config
-CONFIG=$(pwd)/minetest.conf
+CONFIG=/tmp/technic_minetest.conf
 echo "mtinfo.autoshutdown = true" > ${CONFIG}
 
 # prepare dependent mods

--- a/generate-mtinfo.sh
+++ b/generate-mtinfo.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# prepare config
+CONFIG=$(pwd)/minetest.conf
+echo "mtinfo.autoshutdown = true" > ${CONFIG}
+
+# prepare dependent mods
+WORLDMODS_DIR=/tmp/technic_worldmods
+git clone --depth=1 https://gitlab.com/VanessaE/basic_materials.git ${WORLDMODS_DIR}/basic_materials
+git clone --depth=1 https://gitlab.com/VanessaE/pipeworks.git ${WORLDMODS_DIR}/pipeworks
+git clone --depth=1 https://gitlab.com/VanessaE/unifieddyes.git ${WORLDMODS_DIR}/unifieddyes
+git clone --depth=1 https://github.com/BuckarooBanzay/mtinfo.git ${WORLDMODS_DIR}/mtinfo
+cp . ${WORLDMODS_DIR}/technic -R
+
+# start container with mtinfo
+docker run --rm -i \
+	--user root \
+	-v ${CONFIG}:/etc/minetest/minetest.conf:ro \
+  -v ${WORLDMODS_DIR}/:/root/.minetest/worlds/world/worldmods \
+	-v $(pwd)/output:/root/.minetest/worlds/world/mtinfo \
+	registry.gitlab.com/minetest/minetest/server:5.3.0
+
+test -f $(pwd)/output/index.html || exit 1
+test -f $(pwd)/output/data/items.js || exit 1
+test -d $(pwd)/output/textures || exit 1

--- a/minetest.conf
+++ b/minetest.conf
@@ -1,1 +1,0 @@
-mtinfo.autoshutdown = true

--- a/minetest.conf
+++ b/minetest.conf
@@ -1,0 +1,1 @@
+mtinfo.autoshutdown = true


### PR DESCRIPTION
this PR adds a workflow to generate a documentation with the help of the `mtinfo` mod

it is not very polished yet but it is a working and clickable recipe- and item-info browser.

## Links

* Example: https://buckaroobanzay.github.io/mtinfo/#/mods/default/items
* Repo: https://github.com/BuckarooBanzay/mtinfo/