### PR TITLE
add max-depth option to quarry

### DIFF
--- a/technic/doc/digilines.md
+++ b/technic/doc/digilines.md
@@ -118,11 +118,13 @@ Some strings will automatically be converted to tables:
 - `"off"` :arrow_right: `{command = "off"}`
 - `"restart` :arrow_right: `{command = "restart"}`
 - `"radius "..value` :arrow_right: `{command = "radius", value = value}`
+- `"max_depth "..value` :arrow_right: `{command = "max_depth", value = value}`
 
 The commands:
-- `"get"`: The forcefield emitter sends back a table containing:
+- `"get"`: The quarry sends back a table containing:
   - `"enabled"`: `0` is off, `1` is on.
   - `"radius"`
+  - `"max_depth"`
   - `"finished"`
   - `"dug_nodes"`
   - `"dig_level"`: A negative value means above the quarry, a positive value means below.


### PR DESCRIPTION
This PR adds a `max_depth` config to the HV Quarry to set the maximum depth it should dig.
Usable via formspec and digilines (see docs)

![Screenshot_2021-06-04_13-36-17](https://user-images.githubusercontent.com/39065740/120795658-0e158b00-c53a-11eb-961b-9ea13da86ecb.png)
