### PR TITLE
return default value on `technic.get_max_lag()` when the parsing fails

### DIFF
--- a/technic/max_lag.lua
+++ b/technic/max_lag.lua
@@ -8,8 +8,11 @@ local function explode(sep, input)
         return t
 end
 
+--- get the engines current max-lag value
+-- returns the current max-lag value or 0 if the value
+-- could not be parsed from the `/status` string
 function technic.get_max_lag()
 	local arrayoutput = explode(", ",minetest.get_server_status())
 	local arrayoutput2 = explode("=",arrayoutput[4])
-	return tonumber(arrayoutput2[1])
+	return tonumber(arrayoutput2[1]) or 0
 end


### PR DESCRIPTION
fixes #191 