### PR TITLE
Re-add recipe for wrench enabled by setting `enable_wrench_crafting`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Recommended mods that build on the `technic mod`:
 | enable_mining_drill                          |                                                                                                                       |
 | enable_mining_laser                          |                                                                                                                       |
 | enable_flashlight                            |                                                                                                                       |
+| enable_wrench                                | enable recipe for wrench                                                                                              |
 | enable_wind_mill                             |                                                                                                                       |
 | enable_frames                                |                                                                                                                       |
 | enable_corium_griefing                       |                                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Recommended mods that build on the `technic mod`:
 | enable_mining_drill                          |                                                                                                                       |
 | enable_mining_laser                          |                                                                                                                       |
 | enable_flashlight                            |                                                                                                                       |
-| enable_wrench                                | enable recipe for wrench                                                                                              |
+| enable_wrench_crafting                       | enable recipe for wrench                                                                                              |
 | enable_wind_mill                             |                                                                                                                       |
 | enable_frames                                |                                                                                                                       |
 | enable_corium_griefing                       |                                                                                                                       |

--- a/technic/config.lua
+++ b/technic/config.lua
@@ -12,7 +12,7 @@ local defaults = {
 	enable_sonic_screwdriver = "true",
 	enable_tree_tap = "true",
 	enable_vacuum = "true",
-	enable_wrench = "false",
+	enable_wrench_crafting = "false",
 
 	-- Power tool options
 	multimeter_remote_start_ttl = "300",

--- a/technic/config.lua
+++ b/technic/config.lua
@@ -12,6 +12,7 @@ local defaults = {
 	enable_sonic_screwdriver = "true",
 	enable_tree_tap = "true",
 	enable_vacuum = "true",
+	enable_wrench = "false",
 
 	-- Power tool options
 	multimeter_remote_start_ttl = "300",

--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -177,3 +177,14 @@ minetest.register_tool("wrench:wrench", {
 		return itemstack
 	end,
 })
+
+if technic.config:get_bool("enable_wrench") then
+	minetest.register_craft({
+		output = "wrench:wrench",
+		recipe = {
+			{"technic:carbon_steel_ingot", "",                           "technic:carbon_steel_ingot"},
+			{"",                           "technic:carbon_steel_ingot", ""},
+			{"",                           "technic:carbon_steel_ingot", ""},
+		},
+	})
+end

--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -178,7 +178,7 @@ minetest.register_tool("wrench:wrench", {
 	end,
 })
 
-if technic.config:get_bool("enable_wrench") then
+if technic.config:get_bool("enable_wrench_crafting") then
 	minetest.register_craft({
 		output = "wrench:wrench",
 		recipe = {


### PR DESCRIPTION
In https://github.com/mt-mods/technic/commit/0cf4133b9718b95dc65b5357892255a5115919e8#diff-e7695eae6c408f2bf28f6f5d33b7c9665bf5cfef90f6281e9502edb8ff3f8069 the wrench recipe was removed.

This patch re-adds the wrench recipe when enable_wrench = yes in $worldpath/technic.conf
