### PR TITLE
stacked CLU's in upgrade slots possible

### DIFF
--- a/technic/doc/machines.md
+++ b/technic/doc/machines.md
@@ -40,9 +40,7 @@ some way.  Generally, machines of MV and HV tiers have two upgrade slots,
 and machines of lower tiers (fuel-fired and LV) do not.  Any item can
 be placed in an upgrade slot, but only specific items will have any
 upgrading effect.  It is possible to have multiple upgrades of the same
-type, but this can't be achieved by stacking more than one upgrade item
-in one slot: it is necessary to put the same kind of item in more than one
-upgrade slot.  The ability to upgrade machines is therefore very limited.
+type.  The ability to upgrade machines is therefore very limited.
 Two kinds of upgrade are currently possible: an energy upgrade and a
 tube upgrade.
 


### PR DESCRIPTION
This PR allows stacking CLU's (technic:control_logic_unit) in upgrade slots. Each additional CLU increases (linearly) the ejection of the finished items. 
For example, 8 CLUs in the HV furnace prevent the target slots from filling up when burning iron dust.

Examples:

Iron ore in HV Grinder
- with 2 CLUs the target slots are full after approx. 184s
- with 7 CLUs the target slots are no longer full

Burning iron dust in HV furnace
- with 2 CLUs the target slots are full after approx. 144s
- with 8 CLUs the target slots are no longer full