### PR TITLE
Disable repair recipes for crystals and batteries

### DIFF
--- a/technic/items.lua
+++ b/technic/items.lua
@@ -27,6 +27,7 @@ minetest.register_tool("technic:blue_energy_crystal", {
 		"technic_diamond_block_blue.png",
 		"technic_diamond_block_blue.png",
 		"technic_diamond_block_blue.png"),
+	groups = { disable_repair = 1 },
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	tool_capabilities = {
@@ -43,6 +44,7 @@ minetest.register_tool("technic:green_energy_crystal", {
 		"technic_diamond_block_green.png",
 		"technic_diamond_block_green.png",
 		"technic_diamond_block_green.png"),
+	groups = { disable_repair = 1 },
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	tool_capabilities = {
@@ -59,6 +61,7 @@ minetest.register_tool("technic:red_energy_crystal", {
 		"technic_diamond_block_red.png",
 		"technic_diamond_block_red.png",
 		"technic_diamond_block_red.png"),
+	groups = { disable_repair = 1 },
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	tool_capabilities = {

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -69,6 +69,7 @@ minetest.register_craft({
 minetest.register_tool("technic:battery", {
 	description = S("RE Battery"),
 	inventory_image = "technic_battery.png",
+	groups = { disable_repair = 1 },
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	tool_capabilities = {


### PR DESCRIPTION
Should probably test a bit, I've not done any testing.
Changes are simply based on Lua API documentation.

Also maybe test better how those actually behave in game before these changes, I've also not tested that at all.