### PR TITLE
Move infotext set before swap_node and technic_on_disable

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -78,12 +78,18 @@ Used itemdef fields
 * `connect_sides`
 	* In addition to the default use (see lua_api.txt), this tells where the
 	  machine can be connected.
-#
-#
 * `technic_run(pos, node)`
 	* This function is currently used to update the node.
-	  Modders have to manually change the information about supply etc. in the
-	  node metadata.
+* `wear_represents = "string"`
+	* Specifies how the tool wear level is handled. Available modes:
+		* `"mechanical_wear"`: represents physical damage
+		* `"technic_RE_charge"`: represents electrical charge
+* `<itemdef>.technic_run = function(pos, node) ...`
+	* This callback is used to update the node.
+* `<itemdef>.technic_disabled_machine_name = "string"`
+	* Specifies the machine's node name to use when it's not connected connected to a network
+* `<itemdef>.technic_on_disable = function(pos, node) ...`
+	* This callback is run when the machine is no longer connected to a technic-powered network.
 
 Machine types
 -------------

--- a/technic/machines/network.lua
+++ b/technic/machines/network.lua
@@ -195,15 +195,16 @@ technic.touch_node = touch_node
 
 function technic.disable_machine(pos, node)
 	local nodedef = minetest.registered_nodes[node.name]
-	if nodedef and nodedef.technic_disabled_machine_name then
-		node.name = nodedef.technic_disabled_machine_name
-		minetest.swap_node(pos, node)
-	elseif nodedef and nodedef.technic_on_disable then
-		nodedef.technic_on_disable(pos, node)
-	end
 	if nodedef then
 		local meta = minetest.get_meta(pos)
 		meta:set_string("infotext", S("%s Has No Network"):format(nodedef.description))
+	end
+	if nodedef and nodedef.technic_disabled_machine_name then
+		node.name = nodedef.technic_disabled_machine_name
+		minetest.swap_node(pos, node)
+	end
+	if nodedef and nodedef.technic_on_disable then
+		nodedef.technic_on_disable(pos, node)
 	end
 	local node_id = poshash(pos)
 	for _,nodes in pairs(node_timeout) do


### PR DESCRIPTION
callback. (technic_on_disable callback can rewrite it.)

Technic_on-disable callback is now called always when it is defined.

Closes #206 
(See issue on minetest-mods/technic for more info)