### PR TITLE
Extended Mineunit tests

### DIFF
--- a/technic/spec/building_spec.lua
+++ b/technic/spec/building_spec.lua
@@ -1,37 +1,16 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
 -- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-
-fixture("pipeworks")
 fixture("network")
 
-sourcefile("machines/network")
-
-sourcefile("machines/register/cables")
-sourcefile("machines/LV/cables")
-sourcefile("machines/MV/cables")
-sourcefile("machines/HV/cables")
-
-sourcefile("machines/register/generator")
-sourcefile("machines/HV/generator")
-
-function get_network_fixture(sw_pos)
-	-- Build network
-	local net_id = technic.create_network(sw_pos)
-	assert.is_number(net_id)
-	local net = technic.networks[net_id]
-	assert.is_table(net)
-	return net
-end
-
 describe("Power network building", function()
+
+	sourcefile("machines/register/generator")
+	sourcefile("machines/HV/generator")
 
 	describe("cable building", function()
 

--- a/technic/spec/cnc_spec.lua
+++ b/technic/spec/cnc_spec.lua
@@ -1,0 +1,156 @@
+require("mineunit")
+--[[
+	Technic network unit tests.
+	Execute busted at technic source directory.
+--]]
+
+-- Load fixtures required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+
+fixture("pipeworks")
+fixture("network")
+fixture("default")
+fixture("technic_worldgen")
+
+sourcefile("init")
+
+describe("Technic CNC", function()
+
+	fixture("technic_cnc")
+
+	local player = Player("SX")
+
+	-- Helper function to execute netowork
+	local function run_network(times)
+		times = times or 1
+		for i=1, times do
+			-- Globalstep every second instead of every 0.1 seconds
+			mineunit:execute_globalstep(1)
+		end
+	end
+
+	-- Helper function to place itemstack into machine inventory
+	local function place_itemstack(pos, itemstack, listname)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		if not inv:room_for_item(listname or "src", itemstack) then
+			inv:set_stack(listname or "src", 1, ItemStack())
+		end
+		inv:add_item(listname or "src", itemstack)
+	end
+
+	-- Get itemstack in inventory for inspection without removing it
+	local function get_itemstack(pos, listname, index)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		return inv:get_stack(listname or "dst", index or 1)
+	end
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	local cnc_pos = {x=0,y=1,z=0}
+	local program = next(technic_cnc.products)
+	local product_count = technic_cnc.products[program]
+
+	describe("technic:cnc", function()
+
+		setup(function()
+			world.clear()
+			for x = 0, 4 do
+				world.place_node({x=x,y=0,z=0}, "technic:lv_cable", player)
+			end
+			world.place_node(cnc_pos, "technic:cnc", player)
+			world.place_node({x=1,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=2,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=3,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=4,y=1,z=0}, "technic:switching_station", player)
+		end)
+
+		it("produces items", function()
+			local id = technic.pos2network(cnc_pos)
+			local net = technic.networks[id]
+			assert.not_nil(net)
+
+			-- Fill input inventory and select program
+			local on_receive_fields = minetest.registered_nodes["technic:cnc"].on_receive_fields
+			assert.equals("function", type(on_receive_fields))
+			place_itemstack(cnc_pos, "default:wood 99")
+			on_receive_fields(cnc_pos, nil, {[program] = true}, player)
+
+			-- Run network and check results
+			run_network(10)
+			local products = get_itemstack(cnc_pos)
+			assert.is_ItemStack(products)
+			assert.gt(products:get_count(), product_count)
+		end)
+
+		it("uses energy", function()
+			place_itemstack(cnc_pos, "default:wood 99")
+			local id = technic.pos2network(cnc_pos)
+			local net = technic.networks[id]
+			assert.not_nil(net)
+
+			-- Run network and check results
+			run_network()
+			assert.equal(net.demand, 450)
+		end)
+
+	end)
+
+	describe("technic:cnc_mk2", function()
+
+		setup(function()
+			world.clear()
+			for x = 0, 7 do
+				world.place_node({x=x,y=0,z=0}, "technic:lv_cable", player)
+			end
+			world.place_node(cnc_pos, "technic:cnc_mk2", player)
+			world.place_node({x=1,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=2,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=3,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=4,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=5,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=6,y=1,z=0}, "technic:solar_array_lv", player)
+			world.place_node({x=7,y=1,z=0}, "technic:switching_station", player)
+		end)
+
+		it("produces items", function()
+			local id = technic.pos2network(cnc_pos)
+			local net = technic.networks[id]
+			assert.not_nil(net)
+
+			-- Fill input inventory and select program
+			local on_receive_fields = minetest.registered_nodes["technic:cnc_mk2"].on_receive_fields
+			assert.equals("function", type(on_receive_fields))
+			place_itemstack(cnc_pos, "default:wood 99")
+			on_receive_fields(cnc_pos, nil, {[program] = true}, player)
+
+			-- Run network and check results
+			run_network(10)
+			local products = get_itemstack(cnc_pos)
+			assert.is_ItemStack(products)
+			assert.gt(products:get_count(), product_count)
+		end)
+
+		it("uses energy", function()
+			place_itemstack(cnc_pos, "default:wood 99")
+			local id = technic.pos2network(cnc_pos)
+			local net = technic.networks[id]
+			assert.not_nil(net)
+
+			-- Run network and check results
+			run_network()
+			assert.equal(net.demand, 900)
+		end)
+
+	end)
+
+end)

--- a/technic/spec/cnc_spec.lua
+++ b/technic/spec/cnc_spec.lua
@@ -1,23 +1,11 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
--- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-mineunit("common/after")
-mineunit("server")
-mineunit("voxelmanip")
-
-fixture("pipeworks")
-fixture("network")
-fixture("default")
-fixture("technic_worldgen")
-
-sourcefile("init")
+-- Load complete technic mod
+fixture("technic")
 
 describe("Technic CNC", function()
 

--- a/technic/spec/fixtures/default.lua
+++ b/technic/spec/fixtures/default.lua
@@ -1,15 +1,24 @@
 
--- Screwdriver is listed as optional but mod crashes without it
-_G.screwdriver = {}
-
-local function register_default(name, def)
-	def = def or {}
-	def.description = def.description or (name.." description")
-	minetest.register_node(":default:"..name, def)
+local function register_node(name)
+	minetest.register_node(":default:"..name, {
+		description = name.." description",
+		tiles = { "default_"..name },
+		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2},
+	})
 end
 
-register_default("furnace")
-register_default("sand")
-register_default("sandstone")
-register_default("steelblock")
-register_default("steel_ingot")
+local function register_item(name)
+	minetest.register_craftitem(":default:"..name, {
+		description = name.." description",
+	})
+end
+
+register_node("furnace")
+register_node("stone")
+register_node("cobble")
+register_node("sand")
+register_node("sandstone")
+register_node("wood")
+register_node("steelblock")
+
+register_item("steel_ingot")

--- a/technic/spec/fixtures/default.lua
+++ b/technic/spec/fixtures/default.lua
@@ -1,0 +1,15 @@
+
+-- Screwdriver is listed as optional but mod crashes without it
+_G.screwdriver = {}
+
+local function register_default(name, def)
+	def = def or {}
+	def.description = def.description or (name.." description")
+	minetest.register_node(":default:"..name, def)
+end
+
+register_default("furnace")
+register_default("sand")
+register_default("sandstone")
+register_default("steelblock")
+register_default("steel_ingot")

--- a/technic/spec/fixtures/mesecons.lua
+++ b/technic/spec/fixtures/mesecons.lua
@@ -1,0 +1,26 @@
+mineunit:set_modpath("mesecons", "spec/fixtures")
+mineunit:set_modpath("mesecons_mvps", "spec/fixtures")
+
+mesecon = {
+	state = {},
+	rules = {
+		default = {
+			{x =  0, y =  0, z = -1},
+			{x =  1, y =  0, z =  0},
+			{x = -1, y =  0, z =  0},
+			{x =  0, y =  0, z =  1},
+			{x =  1, y =  1, z =  0},
+			{x =  1, y = -1, z =  0},
+			{x = -1, y =  1, z =  0},
+			{x = -1, y = -1, z =  0},
+			{x =  0, y =  1, z =  1},
+			{x =  0, y = -1, z =  1},
+			{x =  0, y =  1, z = -1},
+			{x =  0, y = -1, z = -1},
+		}
+	}
+}
+mesecon = setmetatable(mesecon, {
+	__call = function(self,...) return self end,
+	__index = function(...) return function(...)end end,
+})

--- a/technic/spec/fixtures/mesecons.lua
+++ b/technic/spec/fixtures/mesecons.lua
@@ -20,6 +20,7 @@ mesecon = {
 		}
 	}
 }
+
 mesecon = setmetatable(mesecon, {
 	__call = function(self,...) return self end,
 	__index = function(...) return function(...)end end,

--- a/technic/spec/fixtures/network.lua
+++ b/technic/spec/fixtures/network.lua
@@ -1,4 +1,16 @@
 
+-- Do not use this fixture when loading full Technic mod.
+-- This is made available to allow loading only small part of mod, specifically network core.
+
+-- Load modules required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+
+-- Load fixtures required by tests
+fixture("default")
+fixture("pipeworks")
+
 _G.technic = {}
 _G.technic.S = string.format
 _G.technic.modpath = "."
@@ -23,3 +35,19 @@ sourcefile("register")
 technic.register_tier("LV", "Busted LV")
 technic.register_tier("MV", "Busted MV")
 technic.register_tier("HV", "Busted HV")
+
+sourcefile("machines/network")
+
+sourcefile("machines/register/cables")
+sourcefile("machines/LV/cables")
+sourcefile("machines/MV/cables")
+sourcefile("machines/HV/cables")
+
+function get_network_fixture(sw_pos)
+	-- Build network
+	local net_id = technic.create_network(sw_pos)
+	assert.is_number(net_id)
+	local net = technic.networks[net_id]
+	assert.is_table(net)
+	return net
+end

--- a/technic/spec/fixtures/network.lua
+++ b/technic/spec/fixtures/network.lua
@@ -1,6 +1,7 @@
 
 _G.technic = {}
 _G.technic.S = string.format
+_G.technic.modpath = "."
 _G.technic.getter = function(...) return "" end
 _G.technic.get_or_load_node = minetest.get_node
 _G.technic.digilines = {

--- a/technic/spec/fixtures/pipeworks.lua
+++ b/technic/spec/fixtures/pipeworks.lua
@@ -4,5 +4,7 @@ _G.pipeworks = {}
 _G.pipeworks.button_label = ""
 _G.pipeworks.fs_helpers = {}
 _G.pipeworks.fs_helpers.cycling_button = function(...) return "" end
-_G.pipeworks.scan_for_tube_objects = function(...) end
-_G.pipeworks.tube_inject_item = function(...) end
+_G.pipeworks = setmetatable(_G.pipeworks, {
+	__call = function(self,...) return self end,
+	__index = function(...) return function(...)end end,
+})

--- a/technic/spec/fixtures/pipeworks.lua
+++ b/technic/spec/fixtures/pipeworks.lua
@@ -4,3 +4,5 @@ _G.pipeworks = {}
 _G.pipeworks.button_label = ""
 _G.pipeworks.fs_helpers = {}
 _G.pipeworks.fs_helpers.cycling_button = function(...) return "" end
+_G.pipeworks.scan_for_tube_objects = function(...) end
+_G.pipeworks.tube_inject_item = function(...) end

--- a/technic/spec/fixtures/pipeworks.lua
+++ b/technic/spec/fixtures/pipeworks.lua
@@ -4,6 +4,7 @@ _G.pipeworks = {}
 _G.pipeworks.button_label = ""
 _G.pipeworks.fs_helpers = {}
 _G.pipeworks.fs_helpers.cycling_button = function(...) return "" end
+
 _G.pipeworks = setmetatable(_G.pipeworks, {
 	__call = function(self,...) return self end,
 	__index = function(...) return function(...)end end,

--- a/technic/spec/fixtures/technic.conf
+++ b/technic/spec/fixtures/technic.conf
@@ -1,0 +1,30 @@
+enable_cans = true
+enable_chainsaw = true
+enable_flashlight = true
+enable_mining_drill = true
+enable_mining_laser = true
+enable_multimeter = true
+enable_prospector = true
+enable_sonic_screwdriver = true
+enable_tree_tap = true
+enable_vacuum = true
+enable_wrench_crafting = true
+
+multimeter_remote_start_ttl = 300
+
+enable_wind_mill = true
+enable_frames = true
+enable_nuclear_reactor_digiline_selfdestruct = true
+quarry_dig_above_nodes = 3
+quarry_max_depth = 100
+quarry_time_limit = 5000
+
+switch_off_delay_seconds = 1800
+network_overload_reset_time = 20
+admin_priv = basic_privs
+enable_corium_griefing = true
+enable_radiation_protection = true
+enable_radiation_throttling = true
+enable_entity_radiation_damage = true
+enable_longterm_radiation_damage = true
+max_lag_reduction_multiplier = 0.99

--- a/technic/spec/fixtures/technic.lua
+++ b/technic/spec/fixtures/technic.lua
@@ -1,0 +1,20 @@
+
+-- Use this fixture when loading full Technic mod.
+-- Loads all required modules and fixtures for technic
+
+-- Load modules required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+
+-- Load fixtures required by tests
+fixture("default")
+fixture("mesecons")
+fixture("pipeworks")
+fixture("technic_worldgen")
+
+-- Load mod
+sourcefile("init")

--- a/technic/spec/fixtures/technic_cnc.lua
+++ b/technic/spec/fixtures/technic_cnc.lua
@@ -1,12 +1,6 @@
 
 -- Load technic_cnc mod
 
-minetest.register_node(":default:wood", {
-	description = "Wood",
-	tiles = { "default_wood.png" },
-	groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2},
-})
-
 mineunit:set_modpath("technic_cnc", "../technic_cnc")
 
 mineunit:set_current_modname("technic_cnc")

--- a/technic/spec/fixtures/technic_cnc.lua
+++ b/technic/spec/fixtures/technic_cnc.lua
@@ -1,0 +1,14 @@
+
+-- Load technic_cnc mod
+
+minetest.register_node(":default:wood", {
+	description = "Wood",
+	tiles = { "default_wood.png" },
+	groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2},
+})
+
+mineunit:set_modpath("technic_cnc", "../technic_cnc")
+
+mineunit:set_current_modname("technic_cnc")
+sourcefile("../technic_cnc/init")
+mineunit:restore_current_modname()

--- a/technic/spec/fixtures/technic_worldgen.lua
+++ b/technic/spec/fixtures/technic_worldgen.lua
@@ -6,34 +6,3 @@ mineunit:set_modpath("technic_worldgen", "../technic_worldgen")
 mineunit:set_current_modname("technic_worldgen")
 sourcefile("../technic_worldgen/init")
 mineunit:restore_current_modname()
-
---[[
--- Add cooking recipes from technic_worldgen without having to load whole mod
-
-local S = string.format
-
-minetest.register_craftitem(":technic:lead_lump", {
-	description = S("Lead Lump"),
-	inventory_image = "technic_lead_lump.png",
-})
-
-minetest.register_craftitem(":technic:lead_ingot", {
-	description = S("Lead Ingot"),
-	inventory_image = "technic_lead_ingot.png",
-})
-
-minetest.register_craft({
-	type = 'cooking',
-	recipe = "technic:lead_lump",
-	output = "technic:lead_ingot",
-})
-
-minetest.register_node( ":technic:mineral_lead", {
-	description = S("Lead Ore"),
-	tiles = { "default_stone.png^technic_mineral_lead.png" },
-	is_ground_content = true,
-	groups = {cracky=3},
-	sounds = default.node_sound_stone_defaults(),
-	drop = "technic:lead_lump",
-})
---]]

--- a/technic/spec/fixtures/technic_worldgen.lua
+++ b/technic/spec/fixtures/technic_worldgen.lua
@@ -1,0 +1,39 @@
+
+-- Load technic_worldgen mod
+
+mineunit:set_modpath("technic_worldgen", "../technic_worldgen")
+
+mineunit:set_current_modname("technic_worldgen")
+sourcefile("../technic_worldgen/init")
+mineunit:restore_current_modname()
+
+--[[
+-- Add cooking recipes from technic_worldgen without having to load whole mod
+
+local S = string.format
+
+minetest.register_craftitem(":technic:lead_lump", {
+	description = S("Lead Lump"),
+	inventory_image = "technic_lead_lump.png",
+})
+
+minetest.register_craftitem(":technic:lead_ingot", {
+	description = S("Lead Ingot"),
+	inventory_image = "technic_lead_ingot.png",
+})
+
+minetest.register_craft({
+	type = 'cooking',
+	recipe = "technic:lead_lump",
+	output = "technic:lead_ingot",
+})
+
+minetest.register_node( ":technic:mineral_lead", {
+	description = S("Lead Ore"),
+	tiles = { "default_stone.png^technic_mineral_lead.png" },
+	is_ground_content = true,
+	groups = {cracky=3},
+	sounds = default.node_sound_stone_defaults(),
+	drop = "technic:lead_lump",
+})
+--]]

--- a/technic/spec/hv_network_spec.lua
+++ b/technic/spec/hv_network_spec.lua
@@ -1,0 +1,131 @@
+require("mineunit")
+--[[
+	Technic network unit tests.
+	Execute busted at technic source directory.
+--]]
+
+-- Load fixtures required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+
+fixture("pipeworks")
+fixture("network")
+fixture("default")
+fixture("technic_worldgen")
+fixture("mesecons")
+
+sourcefile("init")
+
+describe("HV machine network", function()
+
+	local player = Player("SX")
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	local machines = {
+		"technic:hv_generator",
+		"technic:solar_array_hv",
+		"technic:solar_array_hv",
+		"technic:solar_array_hv",
+		"technic:solar_array_hv",
+		"technic:solar_array_hv",
+		"technic:hv_battery_box0",
+		"technic:hv_electric_furnace",
+		"technic:hv_grinder",
+		"technic:hv_compressor",
+		"technic:hv_nuclear_reactor_core",
+		"technic:quarry",
+	}
+
+	world.clear()
+	world.place_node({x=100,y=1,z=0}, "technic:switching_station", player)
+	for x = 1, 100 do
+		world.place_node({x=x,y=0,z=0}, "technic:hv_cable", player)
+	end
+	for x, name in ipairs(machines) do
+		world.place_node({x=x,y=1,z=0}, name, player)
+	end
+
+	-- Helper function to execute netowork
+	local function run_network(times)
+		times = times or 1
+		for i=1, times do
+			-- Globalstep every second instead of every 0.1 seconds
+			mineunit:execute_globalstep(1)
+		end
+	end
+
+	-- Helper function to place itemstack into machine inventory
+	local function place_itemstack(pos, itemstack, listname)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		if not inv:room_for_item(listname or "src", itemstack) then
+			inv:set_stack(listname or "src", 1, ItemStack())
+		end
+		inv:add_item(listname or "src", itemstack)
+	end
+
+	-- Get itemstack in inventory for inspection without removing it
+	local function get_itemstack(pos, listname, index)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		return inv:get_stack(listname or "dst", index or 1)
+	end
+
+	it("executes network", function()
+		spy.on(technic, "network_run")
+		run_network(60)
+		assert.spy(technic.network_run).called(60)
+		local id = technic.pos2network({x=100,y=0,z=0})
+		assert.not_nil(technic.networks[id])
+		assert.gt(technic.networks[id].supply, 0)
+	end)
+
+	it("kills network when switching station disappear", function()
+		local id = technic.pos2network({x=100,y=0,z=0})
+		assert.not_nil(technic.networks[id])
+		-- Remove switching station and execute globalstep
+		world.set_node({x=100,y=1,z=0}, {name="air"})
+		mineunit:execute_globalstep(1)
+		-- Network should be gone
+		assert.is_nil(technic.networks[id])
+		-- Build new switching station to restore network
+		world.place_node({x=100,y=1,z=0}, {name="technic:switching_station"})
+		mineunit:execute_globalstep(1)
+		assert.not_nil(technic.networks[id])
+	end)
+
+	it("charges battery box", function()
+		local id = technic.pos2network({x=100,y=0,z=0})
+		local net = technic.networks[id]
+		assert.gt(net.battery_charge, 1000)
+	end)
+
+	it("smelts ores", function()
+		local machine_pos = {x=8,y=1,z=0}
+		place_itemstack(machine_pos, "technic:lead_lump 99")
+		run_network(60)
+		-- Check results, at least 10 items processed and results in correct stuff
+		local stack = get_itemstack(machine_pos)
+		assert.gt(stack:get_count(), 10)
+		assert.equals(stack:get_name(), "technic:lead_ingot")
+	end)
+
+	it("grinds ores", function()
+		local machine_pos = {x=9,y=1,z=0}
+		place_itemstack(machine_pos, "technic:lead_lump 99")
+		run_network(60)
+		-- Check results, at least 10 items processed and results in correct stuff
+		local stack = get_itemstack(machine_pos)
+		assert.gt(stack:get_count(), 10)
+		assert.equals(stack:get_name(), "technic:lead_dust")
+	end)
+
+end)

--- a/technic/spec/hv_network_spec.lua
+++ b/technic/spec/hv_network_spec.lua
@@ -1,24 +1,11 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
--- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-mineunit("common/after")
-mineunit("server")
-mineunit("voxelmanip")
-
-fixture("pipeworks")
-fixture("network")
-fixture("default")
-fixture("technic_worldgen")
-fixture("mesecons")
-
-sourcefile("init")
+-- Load complete technic mod
+fixture("technic")
 
 describe("HV machine network", function()
 

--- a/technic/spec/lv_network_spec.lua
+++ b/technic/spec/lv_network_spec.lua
@@ -1,24 +1,11 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
--- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-mineunit("common/after")
-mineunit("server")
-mineunit("voxelmanip")
-
-fixture("pipeworks")
-fixture("network")
-fixture("default")
-fixture("technic_worldgen")
-fixture("mesecons")
-
-sourcefile("init")
+-- Load complete technic mod
+fixture("technic")
 
 describe("LV machine network", function()
 

--- a/technic/spec/lv_network_spec.lua
+++ b/technic/spec/lv_network_spec.lua
@@ -1,0 +1,198 @@
+require("mineunit")
+--[[
+	Technic network unit tests.
+	Execute busted at technic source directory.
+--]]
+
+-- Load fixtures required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+
+fixture("pipeworks")
+fixture("network")
+fixture("default")
+fixture("technic_worldgen")
+fixture("mesecons")
+
+sourcefile("init")
+
+describe("LV machine network", function()
+
+	local player = Player("SX")
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	local machines = {
+		"technic:lv_generator",
+		"technic:geothermal",
+		"technic:solar_panel",
+		"technic:solar_array_lv",
+		"technic:solar_array_lv",
+		"technic:solar_array_lv",
+		"technic:lv_battery_box0",
+		"technic:lv_electric_furnace",
+		"technic:lv_extractor",
+		"technic:lv_grinder",
+		"technic:lv_alloy_furnace",
+		"technic:lv_compressor",
+		"technic:lv_led",
+		"technic:lv_lamp",
+		"technic:water_mill",
+	}
+
+	world.clear()
+	world.place_node({x=100,y=1,z=0}, "technic:switching_station", player)
+	for x = 1, 100 do
+		world.place_node({x=x,y=0,z=0}, "technic:lv_cable", player)
+	end
+	for x, name in ipairs(machines) do
+		world.place_node({x=x,y=1,z=0}, name, player)
+	end
+
+	-- Helper to destroy nodes in test world returning list of removed nodes indexed by coordinates
+	local function remove_nodes(nodes)
+		local removed = {}
+		for x = 1, 100 do
+			local pos = {x=x,y=1,z=0}
+			local node = minetest.get_node(pos)
+			if nodes[node.name] then
+				removed[pos] = node
+				world.remove_node(pos)
+			end
+		end
+		return removed
+	end
+
+	-- Helper to restore nodes removed by remove_nodes function
+	local function restore_nodes(nodes)
+		for pos, node in ipairs(nodes) do
+			world.place_node(pos, node, player)
+		end
+	end
+
+	-- Helper function to execute netowork
+	local function run_network(times)
+		times = times or 1
+		for i=1, times do
+			-- Globalstep every second instead of every 0.1 seconds
+			mineunit:execute_globalstep(1)
+		end
+	end
+
+	-- Helper function to place itemstack into machine inventory
+	local function place_itemstack(pos, itemstack, listname)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		if not inv:room_for_item(listname or "src", itemstack) then
+			inv:set_stack(listname or "src", 1, ItemStack())
+		end
+		inv:add_item(listname or "src", itemstack)
+	end
+
+	-- Get itemstack in inventory for inspection without removing it
+	local function get_itemstack(pos, listname, index)
+		local meta = minetest.get_meta(pos)
+		local inv = meta:get_inventory()
+		return inv:get_stack(listname or "dst", index or 1)
+	end
+
+	it("executes network", function()
+		spy.on(technic, "network_run")
+		run_network(60)
+		assert.spy(technic.network_run).called(60)
+		local id = technic.pos2network({x=100,y=0,z=0})
+		assert.not_nil(technic.networks[id])
+		assert.gt(technic.networks[id].supply, 0)
+	end)
+
+	it("kills network when switching station disappear", function()
+		local id = technic.pos2network({x=100,y=0,z=0})
+		assert.not_nil(technic.networks[id])
+		-- Remove switching station and execute globalstep
+		world.remove_node({x=100,y=1,z=0})
+		run_network()
+		-- Network should be gone
+		assert.is_nil(technic.networks[id])
+		-- Build new switching station to restore network
+		world.place_node({x=100,y=1,z=0}, {name="technic:switching_station"})
+		run_network()
+		assert.not_nil(technic.networks[id])
+	end)
+
+	it("charges battery box", function()
+		local id = technic.pos2network({x=100,y=0,z=0})
+		local net = technic.networks[id]
+		assert.gt(net.battery_charge, 1000)
+	end)
+
+	it("smelts ores", function()
+		local machine_pos = {x=8,y=1,z=0}
+		place_itemstack(machine_pos, "technic:lead_lump 99")
+		run_network(60)
+		-- Check results, at least 10 items processed and results in correct stuff
+		local stack = get_itemstack(machine_pos)
+		assert.gt(stack:get_count(), 10)
+		assert.equals(stack:get_name(), "technic:lead_ingot")
+	end)
+
+	it("grinds ores", function()
+		local machine_pos = {x=10,y=1,z=0}
+		place_itemstack(machine_pos, "technic:lead_lump 99")
+		run_network(60)
+		-- Check results, at least 10 items processed and results in correct stuff
+		local stack = get_itemstack(machine_pos)
+		assert.gt(stack:get_count(), 10)
+		assert.equals(stack:get_name(), "technic:lead_dust")
+	end)
+
+	it("comperess sand", function()
+		local machine_pos = {x=12,y=1,z=0}
+		place_itemstack(machine_pos, "default:sand 99")
+		run_network(60)
+		-- Check results, at least 10 items processed and results in correct stuff
+		local stack = get_itemstack(machine_pos)
+		assert.gt(stack:get_count(), 10)
+		assert.equals(stack:get_name(), "default:sandstone")
+	end)
+
+	it("cuts power when generators disappear", function()
+		place_itemstack({x=8,y=1,z=0}, "technic:lead_lump 99")
+		place_itemstack({x=10,y=1,z=0}, "technic:lead_lump 99")
+		place_itemstack({x=12,y=1,z=0}, "default:sand 99")
+		local id = technic.pos2network({x=100,y=0,z=0})
+		assert.not_nil(technic.networks[id])
+
+		-- Remove generators and run network 60 times
+		local generators = {
+			["technic:solar_panel"] = 1,
+			["technic:solar_array_lv"] = 1,
+		}
+		local restore = remove_nodes(generators)
+
+		-- Verify that network power is down immediately
+		local net = technic.networks[id]
+		run_network(1)
+		assert.equal(net.supply, 0)
+
+		-- Get current battery charge for network and execute few more cycles
+		local battery_charge = net.battery_charge
+		assert.gt(net.battery_charge, 1000)
+		run_network(60)
+
+		-- Verify that significant battery charge was used and network still does not generate energy
+		assert.lt(net.battery_charge, battery_charge / 2)
+		assert.equal(net.supply, 0)
+
+		-- Restore generators to network and run network once
+		restore_nodes(restore)
+		run_network()
+	end)
+
+end)

--- a/technic/spec/mineunit.conf
+++ b/technic/spec/mineunit.conf
@@ -1,0 +1,8 @@
+time_step = 100
+exclude = {
+	-- Integration tests are not part of mod code
+	"integration_test",
+	-- These are commented out, not part of mod without manually editing code
+	"machines/MV/lighting",
+	"machines/MV/power_radiator",
+}

--- a/technic/spec/network_spec.lua
+++ b/technic/spec/network_spec.lua
@@ -1,63 +1,51 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
 -- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-
-fixture("pipeworks")
 fixture("network")
-
-sourcefile("machines/network")
-
-sourcefile("machines/register/cables")
-sourcefile("machines/LV/cables")
-sourcefile("machines/MV/cables")
-sourcefile("machines/HV/cables")
 
 sourcefile("machines/register/generator")
 sourcefile("machines/HV/generator")
 
-world.layout({
-	{{x=100,y=100,z=100}, "technic:lv_cable"},
-	{{x=101,y=100,z=100}, "technic:lv_cable"},
-	{{x=102,y=100,z=100}, "technic:lv_cable"},
-	{{x=103,y=100,z=100}, "technic:lv_cable"},
-	{{x=104,y=100,z=100}, "technic:lv_cable"},
-	{{x=100,y=101,z=100}, "technic:switching_station"},
-
-	{{x=100,y=200,z=100}, "technic:mv_cable"},
-	{{x=101,y=200,z=100}, "technic:mv_cable"},
-	{{x=102,y=200,z=100}, "technic:mv_cable"},
-	{{x=103,y=200,z=100}, "technic:mv_cable"},
-	{{x=104,y=200,z=100}, "technic:mv_cable"},
-	{{x=100,y=201,z=100}, "technic:switching_station"},
-
-	{{x=100,y=300,z=100}, "technic:hv_cable"},
-	{{x=101,y=300,z=100}, "technic:hv_cable"},
-	{{x=102,y=300,z=100}, "technic:hv_cable"},
-	{{x=103,y=300,z=100}, "technic:hv_cable"},
-	{{x=104,y=300,z=100}, "technic:hv_cable"},
-	{{x=100,y=301,z=100}, "technic:switching_station"},
-
-	-- For network lookup function -> returns correct network for position
-	{{x=100,y=500,z=100}, "technic:hv_cable"},
-	{{x=101,y=500,z=100}, "technic:hv_cable"},
-	{{x=102,y=500,z=100}, "technic:hv_cable"},
-	{{x=103,y=500,z=100}, "technic:hv_cable"},
-	{{x=104,y=500,z=100}, "technic:hv_cable"},
-	{{x=100,y=501,z=100}, "technic:hv_generator"},
-	{{x=101,y=501,z=100}, "technic:hv_cable"},
-	{{x=102,y=501,z=100}, "technic:switching_station"},
-	{{x=100,y=502,z=100}, "technic:hv_cable"},
-	{{x=101,y=502,z=100}, "technic:hv_cable"},
-})
-
 describe("Power network helper", function()
+
+	world.layout({
+		{{x=100,y=100,z=100}, "technic:lv_cable"},
+		{{x=101,y=100,z=100}, "technic:lv_cable"},
+		{{x=102,y=100,z=100}, "technic:lv_cable"},
+		{{x=103,y=100,z=100}, "technic:lv_cable"},
+		{{x=104,y=100,z=100}, "technic:lv_cable"},
+		{{x=100,y=101,z=100}, "technic:switching_station"},
+
+		{{x=100,y=200,z=100}, "technic:mv_cable"},
+		{{x=101,y=200,z=100}, "technic:mv_cable"},
+		{{x=102,y=200,z=100}, "technic:mv_cable"},
+		{{x=103,y=200,z=100}, "technic:mv_cable"},
+		{{x=104,y=200,z=100}, "technic:mv_cable"},
+		{{x=100,y=201,z=100}, "technic:switching_station"},
+
+		{{x=100,y=300,z=100}, "technic:hv_cable"},
+		{{x=101,y=300,z=100}, "technic:hv_cable"},
+		{{x=102,y=300,z=100}, "technic:hv_cable"},
+		{{x=103,y=300,z=100}, "technic:hv_cable"},
+		{{x=104,y=300,z=100}, "technic:hv_cable"},
+		{{x=100,y=301,z=100}, "technic:switching_station"},
+
+		-- For network lookup function -> returns correct network for position
+		{{x=100,y=500,z=100}, "technic:hv_cable"},
+		{{x=101,y=500,z=100}, "technic:hv_cable"},
+		{{x=102,y=500,z=100}, "technic:hv_cable"},
+		{{x=103,y=500,z=100}, "technic:hv_cable"},
+		{{x=104,y=500,z=100}, "technic:hv_cable"},
+		{{x=100,y=501,z=100}, "technic:hv_generator"},
+		{{x=101,y=501,z=100}, "technic:hv_cable"},
+		{{x=102,y=501,z=100}, "technic:switching_station"},
+		{{x=100,y=502,z=100}, "technic:hv_cable"},
+		{{x=101,y=502,z=100}, "technic:hv_cable"},
+	})
 
 	-- Simple network position fixtures
 	local net_id = 65536

--- a/technic/spec/nodes_spec.lua
+++ b/technic/spec/nodes_spec.lua
@@ -1,26 +1,15 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
--- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-mineunit("common/after")
-mineunit("server")
-mineunit("voxelmanip")
-
-fixture("pipeworks")
-fixture("network")
-fixture("default")
-fixture("technic_worldgen")
-fixture("mesecons")
-
-sourcefile("init")
+-- Load complete technic mod
+fixture("technic")
 
 describe("Technic node placement", function()
+
+	world.set_default_node({name="air",param2=0})
 
 	local function placement_test(player, name, xpos)
 		return function()
@@ -44,7 +33,6 @@ describe("Technic node placement", function()
 	end
 
 	setup(function()
-		world.clear()
 		mineunit:execute_on_joinplayer(player)
 	end)
 
@@ -55,6 +43,210 @@ describe("Technic node placement", function()
 	for x, nodename in ipairs(nodes) do
 		it("player can place "..nodename, placement_test(player, nodename, x))
 	end
+
+	describe("cable plates", function()
+
+		world.set_node({x=10,y=10,z=10}, "default:stone")
+		world.set_node({x=10,y=20,z=10}, "default:stone")
+		world.set_node({x=10,y=30,z=10}, "default:stone")
+		world.set_node({x=10,y=40,z=10}, "default:stone")
+
+		describe("normal placement", function()
+
+			setup(function()
+				player:get_inventory():set_stack("main", 1, "technic:hv_cable_plate_1 6")
+				player:_reset_player_controls()
+			end)
+
+			it("plate_1", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 10,x = 11,z = 10},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_1", minetest.get_node(pointed_thing.above).name)
+			end)
+
+			it("plate_2", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 11,x = 10,z = 10},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_2", minetest.get_node(pointed_thing.above).name)
+			end)
+
+			it("plate_3", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 10,x = 10,z = 11},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_3", minetest.get_node(pointed_thing.above).name)
+			end)
+
+			it("plate_4", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 10,x = 9,z = 10},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_4", minetest.get_node(pointed_thing.above).name)
+
+			end)
+
+			it("plate_5", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 9,x = 10,z = 10},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_5", minetest.get_node(pointed_thing.above).name)
+
+			end)
+
+			it("plate_6", function()
+				local pointed_thing = {
+					type = "node",
+					above = {y = 10,x = 10,z = 9},
+					under = {y = 10,x = 10,z = 10}
+				}
+				player:do_place(pointed_thing)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pointed_thing.above).name)
+			end)
+
+		end)
+
+		describe("middle aux1 placement", function()
+
+			setup(function()
+				player:get_inventory():set_stack("main", 1, "technic:hv_cable_plate_1 6")
+				player:_set_player_control_state("aux1", true)
+			end)
+
+			it("heading X-", function()
+				local pos = {y = 20,x = 11,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=2, z=0}))
+				player:do_set_look_xyz("X-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_4", minetest.get_node(pos).name)
+			end)
+
+			it("heading Y-", function()
+				local pos = {y = 21,x = 10,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=2, x=0, z=0}))
+				player:do_set_look_xyz("Y-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_5", minetest.get_node(pos).name)
+			end)
+
+			it("heading Z-", function()
+				local pos = {y = 20,x = 10,z = 11}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=0, z=2}))
+				player:do_set_look_xyz("Z-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pos).name)
+			end)
+
+			it("heading X+", function()
+				local pos = {y = 20,x = 9,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=-2, z=0}))
+				player:do_set_look_xyz("X+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_1", minetest.get_node(pos).name)
+
+			end)
+
+			it("heading Y+", function()
+				local pos = {y = 19,x = 10,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=-2, x=0, z=0}))
+				player:do_set_look_xyz("Y+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_2", minetest.get_node(pos).name)
+			end)
+
+			it("heading Z+", function()
+				local pos = {y = 20,x = 10,z = 9}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=0, z=-2}))
+				player:do_set_look_xyz("Z+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_3", minetest.get_node(pos).name)
+			end)
+
+		end)
+
+		describe("aux1 placement pointing X+ edge", function()
+
+			setup(function()
+				player:get_inventory():set_stack("main", 1, "technic:hv_cable_plate_1 2")
+				player:_set_player_control_state("aux1", true)
+			end)
+
+			it("heading Z+", function()
+				local pos = {y = 30,x = 10,z = 9}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=0.4, z=-2}))
+				player:do_set_look_xyz("Z+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_4", minetest.get_node(pos).name)
+			end)
+
+			it("heading Y-", function()
+				local pos = {y = 31,x = 10,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=2, x=0.4, z=0}))
+				player:do_set_look_xyz("Y-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_4", minetest.get_node(pos).name)
+			end)
+
+		end)
+
+		describe("aux1 placement pointing Z+ edge", function()
+
+			setup(function()
+				player:get_inventory():set_stack("main", 1, "technic:hv_cable_plate_1 4")
+				player:_set_player_control_state("aux1", true)
+			end)
+
+			it("heading X-", function()
+				local pos = {y = 40,x = 11,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=2, z=0.4}))
+				player:do_set_look_xyz("X-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pos).name)
+			end)
+
+			it("heading Y-", function()
+				local pos = {y = 41,x = 10,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=2, x=0, z=0.4}))
+				player:do_set_look_xyz("Y-")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pos).name)
+			end)
+
+			it("heading X+", function()
+				local pos = {y = 40,x = 9,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=0, x=-2, z=0.4}))
+				player:do_set_look_xyz("X+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pos).name)
+			end)
+
+			it("heading Y+", function()
+				local pos = {y = 39,x = 10,z = 10}
+				player:do_set_pos_fp(vector.add(pos, {y=-2, x=0, z=0.4}))
+				player:do_set_look_xyz("Y+")
+				player:do_place(pos)
+				assert.equals("technic:hv_cable_plate_6", minetest.get_node(pos).name)
+			end)
+
+		end)
+
+	end)
 
 	it("gloabalstep works", function()
 		for _=1,60 do

--- a/technic/spec/nodes_spec.lua
+++ b/technic/spec/nodes_spec.lua
@@ -1,0 +1,65 @@
+require("mineunit")
+--[[
+	Technic network unit tests.
+	Execute busted at technic source directory.
+--]]
+
+-- Load fixtures required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+
+fixture("pipeworks")
+fixture("network")
+fixture("default")
+fixture("technic_worldgen")
+fixture("mesecons")
+
+sourcefile("init")
+
+describe("Technic node placement", function()
+
+	local function placement_test(player, name, xpos)
+		return function()
+			player:get_inventory():set_stack("main", 1, name)
+			player:do_place({x=xpos, y=1, z=0})
+		end
+	end
+
+	local player = Player("SX")
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	local nodes = {}
+	for nodename, def in pairs(minetest.registered_nodes) do
+		if not (def.groups and def.groups.not_in_creative_inventory) and nodename:find("^technic:") then
+			table.insert(nodes, nodename)
+		end
+	end
+
+	setup(function()
+		world.clear()
+		mineunit:execute_on_joinplayer(player)
+	end)
+
+	teardown(function()
+		mineunit:execute_on_leaveplayer(player)
+	end)
+
+	for x, nodename in ipairs(nodes) do
+		it("player can place "..nodename, placement_test(player, nodename, x))
+	end
+
+	it("gloabalstep works", function()
+		for _=1,60 do
+			mineunit:execute_globalstep(1)
+		end
+	end)
+
+end)

--- a/technic/spec/supply_converter_spec.lua
+++ b/technic/spec/supply_converter_spec.lua
@@ -1,36 +1,15 @@
 require("mineunit")
 --[[
 	Technic network unit tests.
-	Execute busted at technic source directory.
+	Execute mineunit at technic source directory.
 --]]
 
 -- Load fixtures required by tests
-mineunit("core")
-mineunit("player")
-mineunit("protection")
-
-fixture("pipeworks")
 fixture("network")
 
-sourcefile("machines/network")
-
-sourcefile("machines/register/cables")
-sourcefile("machines/LV/cables")
-sourcefile("machines/MV/cables")
-sourcefile("machines/HV/cables")
-
-sourcefile("machines/supply_converter")
-
-function get_network_fixture(sw_pos)
-	-- Build network
-	local net_id = technic.create_network(sw_pos)
-	assert.is_number(net_id)
-	local net = technic.networks[net_id]
-	assert.is_table(net)
-	return net
-end
-
 describe("Supply converter", function()
+
+	sourcefile("machines/supply_converter")
 
 	describe("building", function()
 

--- a/technic_cnc/spec/digilines_spec.lua
+++ b/technic_cnc/spec/digilines_spec.lua
@@ -3,7 +3,7 @@ require("mineunit")
 mineunit("core")
 mineunit("player")
 
-describe("CNC API", function()
+describe("CNC digiline API", function()
 
 	fixture("default")
 	fixture("basic_materials")


### PR DESCRIPTION
### Generic and targeted extended tests for Technic modpack

Not sure if this is good or wanted, Mineunit supports a lot of things but still not even nearly everything.

This PR extends testing a lot but might be too fixed, it might be good thing as it enforces updating tests when there's big changes.
But for exact same reason it might not be wanted, dropping PR here anyway.

### Current status
See comment https://github.com/mt-mods/technic/pull/208#issuecomment-946919098 for complete list of current tests as of 957c2b8.

**Old report:** Test coverage report for technic 9.62% in 10/103 files
**New report:** Test coverage report for technic 64.48% in 117/117 files

### Fixed annoyances

Also mineunit spamming a lot of warning `InvRef:get_list returning list src as reference, this can lead to unxpected results`, that's mineunit issue and not technic or regression test issue.
I do remember adding that warning to mineunit InvRef implementation just because I was not sure if actual minetest engine returns those as references or if it uses deep copies / copy-on-write objects of direct references to original object.

Test run on local machine, how many times these tests complain about possible "unxpected results" (yeah, just noticed typo too 🤣):
```
$ mineunit | grep 'as reference, this can lead to unxpected results' | wc -l
836
```