### PR TITLE
Update chest registration API

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -9,8 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
 
     - id: mineunit
       uses: mt-mods/mineunit-actions@master
@@ -43,6 +41,13 @@ jobs:
         COLOR: "${{ steps.mineunit-cnc.outputs.badge-color }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - id: mineunit-chests
+      uses: mt-mods/mineunit-actions@master
+      with:
+        working-directory: ./technic_chests
+        badge-name: coverage-chests
+        badge-label: Test coverage
+
     - uses: KeisukeYamashita/create-comment@v1
       if: success() && github.event_name == 'pull_request'
       with:
@@ -56,16 +61,29 @@ jobs:
           -----------------------------------------------------
           ${{ steps.mineunit-cnc.outputs.mineunit-report }}
           ```
+          
+          ### Test coverage report for technic chests ${{ steps.mineunit-chests.outputs.coverage-total }} in ${{ steps.mineunit-chests.outputs.coverage-files }} files:
+          ```
+          File          Hits Missed Coverage
+          ----------------------------------
+          ${{ steps.mineunit-chests.outputs.mineunit-report }}
+          ```
+          
           ### Test coverage report for technic ${{ steps.mineunit.outputs.coverage-total }} in ${{ steps.mineunit.outputs.coverage-files }} files:
           ```
           File                                      Hits Missed Coverage
           --------------------------------------------------------------
           ${{ steps.mineunit.outputs.mineunit-report }}
           ```
+          
           ### Raw test runner output for geeks:
           CNC:
           ```
           ${{ steps.mineunit-cnc.outputs.mineunit-stdout }}
+          ```
+          Chests:
+          ```
+          ${{ steps.mineunit-chests.outputs.mineunit-stdout }}
           ```
           Technic:
           ```
@@ -84,6 +102,12 @@ jobs:
           ```
           ${{ steps.mineunit-cnc.outputs.mineunit-stdout }}
           ```
+          
+          ### Regression test log for Technic Chests:
+          ```
+          ${{ steps.mineunit-chests.outputs.mineunit-stdout }}
+          ```
+          
           ### Regression test log for Technic:
           ```
           ${{ steps.mineunit.outputs.mineunit-stdout }}

--- a/technic_chests/chests.lua
+++ b/technic_chests/chests.lua
@@ -1,13 +1,16 @@
 
-local function register_chests(name, data)
-	for _,t in pairs({"", "_locked", "_protected"}) do
-		local data_copy = {}
-		for k, v in pairs(data) do
-			data_copy[k] = v
-		end
+local S = rawget(_G, "intllib") and intllib.Getter() or function(s) return s end
+
+local function register_chests(data)
+	local name = data.description:lower()
+	local type_description = {"Chest", "Locked Chest", "Protected Chest"}
+	for i,t in ipairs({"", "_locked", "_protected"}) do
+		local data_copy = table.copy(data)
 		data_copy.locked = t == "_locked"
 		data_copy.protected = t == "_protected"
-		technic.chests.register_chest(name, data_copy)
+		data_copy.texture_prefix = "technic_"..name.."_chest"
+		data_copy.description = S(("%s %s"):format(data.description, type_description[i]))
+		technic.chests.register_chest(":technic:"..name..t.."_chest", data_copy)
 	end
 end
 
@@ -68,7 +71,8 @@ local function register_crafts(name, material, base_open, base_locked, base_prot
 end
 
 -- Iron
-register_chests("Iron", {
+register_chests({
+	description = "Iron",
 	width = 9,
 	height = 5,
 	sort = true,
@@ -83,7 +87,8 @@ register_crafts(
 )
 
 -- Copper
-register_chests("Copper", {
+register_chests({
+	description = "Copper",
 	width = 12,
 	height = 5,
 	sort = true,
@@ -99,7 +104,8 @@ register_crafts(
 )
 
 -- Silver
-register_chests("Silver", {
+register_chests({
+	description = "Silver",
 	width = 12,
 	height = 6,
 	sort = true,
@@ -116,7 +122,8 @@ register_crafts(
 )
 
 -- Gold
-register_chests("Gold", {
+register_chests({
+	description = "Gold",
 	width = 15,
 	height = 6,
 	sort = true,
@@ -134,7 +141,8 @@ register_crafts(
 )
 
 -- Mithril
-register_chests("Mithril", {
+register_chests({
+	description = "Mithril",
 	width = 15,
 	height = 6,
 	sort = true,

--- a/technic_chests/formspec.lua
+++ b/technic_chests/formspec.lua
@@ -155,7 +155,7 @@ function technic.chests.update_formspec(pos, data, edit_infotext)
 	meta:set_string("formspec", formspec)
 end
 
-function technic.chests.get_receive_fields(data)
+function technic.chests.get_receive_fields(nodename, data)
 	return function(pos, formname, fields, player)
 		if not fields or not player then
 			return
@@ -221,9 +221,9 @@ function technic.chests.get_receive_fields(data)
 				if fields["color_button"..i] then
 					local node = minetest.get_node(pos)
 					if technic.chests.colors[i] then
-						node.name = data.node_name.."_"..technic.chests.colors[i][1]
+						node.name = nodename.."_"..technic.chests.colors[i][1]
 					else
-						node.name = data.node_name
+						node.name = nodename
 					end
 					minetest.swap_node(pos, node)
 					meta:set_int("color", i)

--- a/technic_chests/spec/api_spec.lua
+++ b/technic_chests/spec/api_spec.lua
@@ -1,0 +1,122 @@
+require("mineunit")
+
+mineunit("core")
+mineunit("player")
+mineunit("server")
+
+describe("Chests API", function()
+
+	fixture("default")
+	fixture("digilines")
+	--fixture("pipeworks")
+
+	sourcefile("init")
+
+	-- Our player Sam will be helping, he promised to place some nodes
+	local Sam = Player("Sam")
+
+	-- Construct test world with CNC machines
+	setup(function()
+		world.clear()
+		mineunit:set_current_modname("my_mod_name")
+		mineunit:execute_on_joinplayer(Sam)
+	end)
+
+	teardown(function()
+		mineunit:restore_current_modname()
+	end)
+
+	it("registered builtin chests", function()
+		local materials = {"iron", "copper", "silver", "gold", "mithril"}
+		local types = {"", "_locked", "_protected"}
+		local failed = {}
+		for _,m in ipairs(materials) do
+			for _,t in ipairs(types) do
+				local name = "technic:"..m..t.."_chest"
+				if type(minetest.registered_nodes[name]) ~= "table" then
+					table.insert(failed, name)
+				end
+			end
+		end
+		if #failed > 0 then
+			error("Builtin chest(s) not registered: "..table.concat(failed,", "))
+		end
+	end)
+
+	it("default builtin descriptions", function()
+		local materials = {"iron", "copper", "silver", "gold", "mithril"}
+		local types = {"", "_locked", "_protected"}
+		local failed = {}
+		for _,m in ipairs(materials) do
+			for _,t in ipairs(types) do
+				local name = "technic:"..m..t.."_chest"
+				local description
+				if t == "_locked" then
+					description = ("%s Locked Chest"):format(m:sub(1,1):upper() .. m:sub(2))
+				elseif t == "_protected" then
+					description = ("%s Protected Chest"):format(m:sub(1,1):upper() .. m:sub(2))
+				else
+					description = ("%s Chest"):format(m:sub(1,1):upper() .. m:sub(2))
+				end
+				assert.equals(description, minetest.registered_nodes[name].description)
+			end
+		end
+	end)
+
+	it("registers chest", function()
+		technic.chests.register_chest("my_mod_name:my_special", {
+			description = "My Special",
+			texture_prefix = "my_mod_name_my_special",
+			width = 15,
+			height = 6,
+			sort = true,
+			infotext = true,
+			autosort = true,
+			quickmove = true,
+			digilines = true,
+		})
+		-- Verify node registration
+		assert.is_table(minetest.registered_nodes["my_mod_name:my_special"])
+		-- Try to place it
+		world.place_node({x=-99,y=-999,z=-9999}, {name = "my_mod_name:my_special", param2 = 0}, Sam)
+	end)
+
+	it("registers locked chest", function()
+		technic.chests.register_chest("my_mod_name:my_locked_special", {
+			description = "My Special",
+			texture_prefix = "my_mod_name_my_special",
+			width = 15,
+			height = 6,
+			sort = true,
+			infotext = true,
+			autosort = true,
+			quickmove = true,
+			digilines = true,
+			locked = true
+		})
+		-- Verify node registration
+		assert.is_table(minetest.registered_nodes["my_mod_name:my_locked_special"])
+		-- Try to place it
+		world.place_node({x=-99,y=-999,z=-9998}, {name = "my_mod_name:my_locked_special", param2 = 0}, Sam)
+	end)
+
+	it("registers protected chest", function()
+		technic.chests.register_chest("my_mod_name:my_protected_special", {
+			description = "My Special",
+			texture_prefix = "my_mod_name_my_special",
+			width = 15,
+			height = 6,
+			sort = true,
+			infotext = true,
+			autosort = true,
+			quickmove = true,
+			digilines = true,
+			protected = true
+		})
+		-- Verify node registration
+		assert.is_table(minetest.registered_nodes["my_mod_name:my_protected_special"])
+		-- Try to place it
+		world.place_node({x=-99,y=-999,z=-9997}, {name = "my_mod_name:my_protected_special", param2 = 0}, Sam)
+	end)
+
+end)

--- a/technic_chests/spec/fixtures/default.lua
+++ b/technic_chests/spec/fixtures/default.lua
@@ -1,0 +1,3 @@
+function default.get_hotbar_bg(...)
+	return "dummy"
+end

--- a/technic_chests/spec/fixtures/digilines.lua
+++ b/technic_chests/spec/fixtures/digilines.lua
@@ -1,0 +1,30 @@
+
+mineunit:set_modpath("digilines", "fixtures")
+
+_G.digilines = {
+	_msg_log = {},
+	receptor_send = function(pos, rules, channel, msg)
+		table.insert(_G.digilines._msg_log, {
+			pos = pos,
+			rules = rules,
+			channel = channel,
+			msg = msg,
+		})
+	end,
+	rules = {
+		default = {
+			{x=0,  y=0,  z=-1},
+			{x=1,  y=0,  z=0},
+			{x=-1, y=0,  z=0},
+			{x=0,  y=0,  z=1},
+			{x=1,  y=1,  z=0},
+			{x=1,  y=-1, z=0},
+			{x=-1, y=1,  z=0},
+			{x=-1, y=-1, z=0},
+			{x=0,  y=1,  z=1},
+			{x=0,  y=-1, z=1},
+			{x=0,  y=1,  z=-1},
+			{x=0,  y=-1, z=-1}
+		}
+	}
+}

--- a/technic_chests/spec/mineunit.conf
+++ b/technic_chests/spec/mineunit.conf
@@ -1,0 +1,4 @@
+validate_textures = true
+exclude_textures = {
+	"^my_mod_name"
+}


### PR DESCRIPTION
Basic interface for #231 

API is not complete but more like starting point, allows registering chests from outside and allows extending API without breaking compatibility.
Few very simple automated tests included:
* validate that builtin chests have been registered.
* try to register normal, locked and protected chests with custom names for another mod.