### PR TITLE
Alias `technic:brass_block` CNC nodes

### DIFF
--- a/technic_cnc/materials/init.lua
+++ b/technic_cnc/materials/init.lua
@@ -16,3 +16,11 @@ for _, mod in pairs(optional_mods) do
 		dofile(path .. mod .. ".lua")
 	end
 end
+
+local function alias(old, new)
+	for _,shape in pairs(technic_cnc.programs) do
+		minetest.register_alias(old .. "_" .. shape.suffix, new .. "_" .. shape.suffix)
+	end
+end
+
+alias("technic:brass_block", "basic_materials:brass_block")


### PR DESCRIPTION
Registration was changed to use `basic_materials:brass_block` in https://github.com/mt-mods/technic/commit/e7cc399. This adds the missing aliases for it.