### PR TITLE
fix crash when using wrench on air or object

### DIFF
--- a/wrench/tool.lua
+++ b/wrench/tool.lua
@@ -10,7 +10,7 @@ minetest.register_tool("wrench:wrench", {
 		end
 		local name = player:get_player_name()
 		local pos = pointed_thing.under
-		if minetest.is_protected(pos, name) then
+		if not pos or minetest.is_protected(pos, name) then
 			return
 		end
 		local picked_up, err_msg = wrench.pickup_node(pos, player)


### PR DESCRIPTION
```
2021-11-28 11:44:49: ACTION[Server]: noxus uses wrench:wrench, pointing at [node under=412,5,-442 above=413,5,-442]
2021-11-28 11:44:53: ACTION[Server]: noxus uses wrench:wrench, pointing at [object 26]
2021-11-28 11:44:54: ACTION[Main]: Server: Shutting down
2021-11-28 11:44:54: ACTION[Server]: noxus leaves game. List of players: 
2021-11-28 11:44:56: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'wrench' in callback item_OnUse(): ...netest/minetest.git/bin/../mods/borders/barriers.lua:171: attempt to index local 'pos' (a nil value)
2021-11-28 11:44:56: ERROR[Main]: stack traceback:
2021-11-28 11:44:56: ERROR[Main]:       ...netest/minetest.git/bin/../mods/borders/barriers.lua:171: in function 'is_barrier_node'
2021-11-28 11:44:56: ERROR[Main]:       ...netest/minetest.git/bin/../mods/borders/barriers.lua:442: in function 'is_protected'
2021-11-28 11:44:56: ERROR[Main]:       ...est/minetest.git/bin/../mods/technic/wrench/tool.lua:13: in function <...est/minetest.git/bin/../mods/technic/wrench/tool.lua:7>

```