### PR TITLE
rename functions "wrench.*" to "wrench:*"

### DIFF
--- a/wrench/functions.lua
+++ b/wrench/functions.lua
@@ -34,9 +34,9 @@ local function get_description(def, pos, meta, node, player)
 	return S("%s with items"):format(minetest.registered_nodes[node.name].description)
 end
 
-function wrench.pickup_node(pos, player)
+function wrench:pickup_node(pos, player)
 	local node = minetest.get_node(pos)
-	local def = wrench.registered_nodes[node.name]
+	local def = self.registered_nodes[node.name]
 	if not def then
 		return
 	end
@@ -57,7 +57,7 @@ function wrench.pickup_node(pos, player)
 	for _, listname in pairs(def.lists or {}) do
 		local list = inv:get_list(listname)
 		for i, stack in pairs(list) do
-			if wrench.blacklisted_items[stack:get_name()] then
+			if self.blacklisted_items[stack:get_name()] then
 				local desc = stack:get_definition().description
 				return false, errors.bad_item:format(desc)
 			end
@@ -94,7 +94,7 @@ function wrench.pickup_node(pos, player)
 	return true
 end
 
-function wrench.restore_node(pos, player, stack)
+function wrench:restore_node(pos, player, stack)
 	if not stack then
 		return
 	end
@@ -102,7 +102,7 @@ function wrench.restore_node(pos, player, stack)
 	if not data then
 		return
 	end
-	local def = wrench.registered_nodes[data.name]
+	local def = self.registered_nodes[data.name]
 	if not def then
 		return
 	end

--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -13,16 +13,16 @@ dofile(modpath.."/legacy.lua")
 dofile(modpath.."/functions.lua")
 dofile(modpath.."/tool.lua")
 
-function wrench.register_node(name, def)
-	assert(type(name) == "string", "wrench.register_node invalid type for name")
-	assert(type(def) == "table", "wrench.register_node invalid type for def")
+function wrench:register_node(name, def)
+	assert(type(name) == "string", "wrench:register_node invalid type for name")
+	assert(type(def) == "table", "wrench:register_node invalid type for def")
 	local node_def = minetest.registered_nodes[name]
 	if node_def then
-		wrench.registered_nodes[name] = table.copy(def)
+		self.registered_nodes[name] = table.copy(def)
 		local old_after_place = node_def.after_place_node
 		minetest.override_item(name, {
 			after_place_node = function(...)
-				if not wrench.restore_node(...) and old_after_place then
+				if not wrench:restore_node(...) and old_after_place then
 					return old_after_place(...)
 				end
 			end
@@ -32,11 +32,11 @@ function wrench.register_node(name, def)
 	end
 end
 
-function wrench.blacklist_item(name)
+function wrench:blacklist_item(name)
 	assert(type(name) == "string", "wrench:blacklist_item invalid type for name")
 	local node_def = minetest.registered_items[name]
 	if node_def then
-		wrench.blacklisted_items[name] = true
+		self.blacklisted_items[name] = true
 	else
 		minetest.log("warning", "Attempt to blacklist unknown item for wrench: "..name)
 	end

--- a/wrench/nodes/default.lua
+++ b/wrench/nodes/default.lua
@@ -1,11 +1,11 @@
 
 -- Register nodes from default / minetest_game
 
-wrench.register_node("default:chest", {
+wrench:register_node("default:chest", {
 	lists = {"main"},
 })
 
-wrench.register_node("default:chest_locked", {
+wrench:register_node("default:chest_locked", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
@@ -14,7 +14,7 @@ wrench.register_node("default:chest_locked", {
 	owned = true,
 })
 
-wrench.register_node("default:furnace", {
+wrench:register_node("default:furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -25,7 +25,7 @@ wrench.register_node("default:furnace", {
 	},
 })
 
-wrench.register_node("default:furnace_active", {
+wrench:register_node("default:furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -46,7 +46,7 @@ local function get_sign_description(pos, meta, node)
 	return string.format("%s with text \"%s\"", desc, text)
 end
 
-wrench.register_node("default:sign_wall_wood", {
+wrench:register_node("default:sign_wall_wood", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING
@@ -54,7 +54,7 @@ wrench.register_node("default:sign_wall_wood", {
 	description = get_sign_description,
 })
 
-wrench.register_node("default:sign_wall_steel", {
+wrench:register_node("default:sign_wall_steel", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING

--- a/wrench/nodes/digtron.lua
+++ b/wrench/nodes/digtron.lua
@@ -1,23 +1,23 @@
 
 -- Register wrench support for digtron
 
-wrench.register_node("digtron:battery_holder", {
+wrench:register_node("digtron:battery_holder", {
 	lists = {"batteries"}
 })
 
-wrench.register_node("digtron:inventory", {
+wrench:register_node("digtron:inventory", {
 	lists = {"main"}
 })
 
-wrench.register_node("digtron:fuelstore", {
+wrench:register_node("digtron:fuelstore", {
 	lists = {"fuel"}
 })
 
-wrench.register_node("digtron:combined_storage", {
+wrench:register_node("digtron:combined_storage", {
 	lists = {"main", "fuel"}
 })
 
 -- Blacklist loaded crates to prevent nesting of inventories
 
-wrench.blacklist_item("digtron:loaded_crate")
-wrench.blacklist_item("digtron:loaded_locked_crate")
+wrench:blacklist_item("digtron:loaded_crate")
+wrench:blacklist_item("digtron:loaded_locked_crate")

--- a/wrench/nodes/drawers.lua
+++ b/wrench/nodes/drawers.lua
@@ -28,9 +28,9 @@ for _, drawer_type in ipairs({1, 2, 4}) do
 		def.metas["stack_max_factor" .. suffix] = INT
 	end
 
-	wrench.register_node("drawers:wood" .. drawer_type, def)
-	wrench.register_node("drawers:acacia_wood" .. drawer_type, def)
-	wrench.register_node("drawers:aspen_wood" .. drawer_type, def)
-	wrench.register_node("drawers:junglewood" .. drawer_type, def)
-	wrench.register_node("drawers:pine_wood" .. drawer_type, def)
+	wrench:register_node("drawers:wood" .. drawer_type, def)
+	wrench:register_node("drawers:acacia_wood" .. drawer_type, def)
+	wrench:register_node("drawers:aspen_wood" .. drawer_type, def)
+	wrench:register_node("drawers:junglewood" .. drawer_type, def)
+	wrench:register_node("drawers:pine_wood" .. drawer_type, def)
 end

--- a/wrench/nodes/technic.lua
+++ b/wrench/nodes/technic.lua
@@ -14,7 +14,7 @@ local function register_machine_node(nodename, tier)
 		tube_time = tier ~= "LV" and wrench.META_TYPE_INT or nil,
 		src_time = wrench.META_TYPE_INT,
 	}
-	wrench.register_node(nodename, {lists = lists, metas = metas})
+	wrench:register_node(nodename, {lists = lists, metas = metas})
 end
 
 -- base_machines table row format: name = { extra meta fields }
@@ -42,7 +42,7 @@ end
 ---------------------------------------------------------------------
 -- Special nodes
 
-wrench.register_node("technic:coal_alloy_furnace", {
+wrench:register_node("technic:coal_alloy_furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -53,7 +53,7 @@ wrench.register_node("technic:coal_alloy_furnace", {
 	},
 })
 
-wrench.register_node("technic:coal_alloy_furnace_active", {
+wrench:register_node("technic:coal_alloy_furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -64,7 +64,7 @@ wrench.register_node("technic:coal_alloy_furnace_active", {
 	},
 })
 
-wrench.register_node("technic:tool_workshop", {
+wrench:register_node("technic:tool_workshop", {
 	lists = {"src", "upgrade1", "upgrade2"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -77,7 +77,7 @@ wrench.register_node("technic:tool_workshop", {
 
 for _, tier in pairs({"LV", "MV", "HV"}) do
 	for i = 0, 8 do
-		wrench.register_node("technic:"..tier:lower().."_battery_box"..i, {
+		wrench:register_node("technic:"..tier:lower().."_battery_box"..i, {
 			lists = tier ~= "LV" and machine_invlist_upgrades or machine_invlist,
 			metas = {
 				infotext = wrench.META_TYPE_STRING,

--- a/wrench/nodes/technic_chests.lua
+++ b/wrench/nodes/technic_chests.lua
@@ -54,17 +54,17 @@ local chests_meta = {
 }
 
 for name, metas in pairs(chests_meta) do
-	wrench.register_node("technic:"..name.."_chest", {
+	wrench:register_node("technic:"..name.."_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:"..name.."_protected_chest", {
+	wrench:register_node("technic:"..name.."_protected_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:"..name.."_locked_chest", {
+	wrench:register_node("technic:"..name.."_locked_chest", {
 		lists = {"main"},
 		metas = with_owner_field(metas),
 		description = get_chest_description,
@@ -93,17 +93,17 @@ local chest_mark_colors = {
 }
 
 for i = 1, 15 do
-	wrench.register_node("technic:gold_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = with_owner_field(chests_meta.gold),
 		description = get_chest_description,

--- a/wrench/nodes/technic_cnc.lua
+++ b/wrench/nodes/technic_cnc.lua
@@ -2,10 +2,10 @@
 -- Register wrench support for Technic CNC
 
 local function register_cnc(name, def)
-	wrench.register_node(name, def)
+	wrench:register_node(name, def)
 	if minetest.registered_nodes[name.."_active"] then
 		-- Only available if technic is active
-		wrench.register_node(name.."_active", def)
+		wrench:register_node(name.."_active", def)
 	end
 end
 

--- a/wrench/tool.lua
+++ b/wrench/tool.lua
@@ -13,7 +13,7 @@ minetest.register_tool("wrench:wrench", {
 		if not pos or minetest.is_protected(pos, name) then
 			return
 		end
-		local picked_up, err_msg = wrench.pickup_node(pos, player)
+		local picked_up, err_msg = wrench:pickup_node(pos, player)
 		if not picked_up then
 			if err_msg then
 				minetest.chat_send_player(name, err_msg)


### PR DESCRIPTION
https://github.com/mt-mods/wrench/issues/3

TODO: restore 'wrench:original_name'