### PR TITLE
remove monitoring metrics

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,7 +26,7 @@ read_globals = {
 	"mesecon", "moretrees",
 	"unified_inventory", "protector",
 	"unifieddyes", "digiline_remote",
-	"monitoring", "drawers", "mg",
+	"drawers", "mg",
 	"craftguide", "i3",
 
 	-- Only used in technic/machines/MV/lighting.lua (disabled)

--- a/technic/machines/switching_station_globalstep.lua
+++ b/technic/machines/switching_station_globalstep.lua
@@ -29,13 +29,9 @@ minetest.register_globalstep(function(dtime)
 
 	local now = minetest.get_us_time()
 
-	local active_switches = 0
-
 	for network_id, network in pairs(technic.active_networks) do
 		if network.timeout > now and not technic.is_overloaded(network_id) then
 			-- station active
-			active_switches = active_switches + 1
-
 			if network.skip > 0 then
 				network.skip = network.skip - 1
 			else

--- a/technic/machines/switching_station_globalstep.lua
+++ b/technic/machines/switching_station_globalstep.lua
@@ -1,20 +1,3 @@
-
-local has_monitoring_mod = minetest.get_modpath("monitoring")
-
-local active_switching_stations_metric, switching_stations_usage_metric
-
-if has_monitoring_mod then
-	active_switching_stations_metric = monitoring.gauge(
-		"technic_active_switching_stations",
-		"Number of active switching stations"
-	)
-
-	switching_stations_usage_metric = monitoring.counter(
-		"technic_switching_stations_usage",
-		"usage in microseconds cpu time"
-	)
-end
-
 -- the interval between technic_run calls
 local technic_run_interval = 1.0
 local set_default_timeout = technic.set_default_timeout
@@ -91,13 +74,6 @@ minetest.register_globalstep(function(dtime)
 			technic.active_networks[network_id] = nil
 		end
 	end
-
-	if has_monitoring_mod then
-		local time_usage = minetest.get_us_time() - now
-		active_switching_stations_metric.set(active_switches)
-		switching_stations_usage_metric.inc(time_usage)
-	end
-
 end)
 
 minetest.register_chatcommand("technic_flush_switch_cache", {

--- a/technic/mod.conf
+++ b/technic/mod.conf
@@ -1,3 +1,3 @@
 name = technic
 depends = default, pipeworks, technic_worldgen, basic_materials, moreores
-optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, vector_extras, dye, monitoring, craftguide, i3
+optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, vector_extras, dye, craftguide, i3


### PR DESCRIPTION
replaced with https://github.com/minetest-monitoring/monitoring_technic/pull/1

the `monitoring` dependency is removed entirely