### PR TITLE
Reduce solar arrays for tests

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -3,18 +3,18 @@ name: mineunit
 on: [push, pull_request]
 
 jobs:
-  build:
+  mineunit:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - id: mineunit
-      uses: mt-mods/mineunit-actions@master
+      uses: mt-mods/mineunit-actions@docker
       with:
         working-directory: ./technic
-        mineunit-args: --fetch-core 5.4.1 --engine-version 5.4.1
+        mineunit-args: --engine-version 5.4.1
         badge-label: Test coverage
 
     - uses: RubbaBoy/BYOB@v1.3.0
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - id: mineunit-cnc
-      uses: mt-mods/mineunit-actions@master
+      uses: mt-mods/mineunit-actions@docker
       with:
         working-directory: ./technic_cnc
         badge-name: coverage-cnc
@@ -43,7 +43,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - id: mineunit-chests
-      uses: mt-mods/mineunit-actions@master
+      uses: mt-mods/mineunit-actions@docker
       with:
         working-directory: ./technic_chests
         badge-name: coverage-chests

--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - id: mineunit
-      uses: mt-mods/mineunit-actions@docker
+      uses: mt-mods/mineunit-actions@master
       with:
         working-directory: ./technic
         mineunit-args: --engine-version 5.4.1
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - id: mineunit-cnc
-      uses: mt-mods/mineunit-actions@docker
+      uses: mt-mods/mineunit-actions@master
       with:
         working-directory: ./technic_cnc
         badge-name: coverage-cnc
@@ -43,7 +43,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - id: mineunit-chests
-      uses: mt-mods/mineunit-actions@docker
+      uses: mt-mods/mineunit-actions@master
       with:
         working-directory: ./technic_chests
         badge-name: coverage-chests

--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -17,7 +17,7 @@ jobs:
         mineunit-args: --fetch-core 5.4.1 --engine-version 5.4.1
         badge-label: Test coverage
 
-    - uses: RubbaBoy/BYOB@v1.2.0
+    - uses: RubbaBoy/BYOB@v1.3.0
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
         NAME: "${{ steps.mineunit.outputs.badge-name }}"
@@ -33,7 +33,7 @@ jobs:
         badge-name: coverage-cnc
         badge-label: Test coverage
 
-    - uses: RubbaBoy/BYOB@v1.2.0
+    - uses: RubbaBoy/BYOB@v1.3.0
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
         NAME: "${{ steps.mineunit-cnc.outputs.badge-name }}"
@@ -48,6 +48,15 @@ jobs:
         working-directory: ./technic_chests
         badge-name: coverage-chests
         badge-label: Test coverage
+
+    - uses: RubbaBoy/BYOB@v1.3.0
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      with:
+        NAME: "${{ steps.mineunit-chests.outputs.badge-name }}"
+        LABEL: "${{ steps.mineunit-chests.outputs.badge-label }}"
+        STATUS: "${{ steps.mineunit-chests.outputs.badge-status }}"
+        COLOR: "${{ steps.mineunit-chests.outputs.badge-color }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: KeisukeYamashita/create-comment@v1
       if: success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/technic/spec/hv_network_spec.lua
+++ b/technic/spec/hv_network_spec.lua
@@ -20,26 +20,22 @@ describe("HV machine network", function()
 
 	local machines = {
 		"technic:hv_generator",
-		"technic:hv_solar_array",
-		"technic:hv_solar_array",
-		"technic:hv_solar_array",
-		"technic:hv_solar_array",
-		"technic:hv_solar_array",
 		"technic:hv_battery_box0",
 		"technic:hv_electric_furnace",
 		"technic:hv_grinder",
 		"technic:hv_compressor",
 		"technic:hv_nuclear_reactor_core",
 		"technic:quarry",
+		"technic:hv_solar_array",
 	}
 
 	world.clear()
-	world.place_node({x=100,y=1,z=0}, "technic:switching_station", player)
-	for x = 1, 100 do
-		world.place_node({x=x,y=0,z=0}, "technic:hv_cable", player)
+	world.place_node({x=0,y=51,z=0}, "technic:switching_station", player)
+	for x = 0, 10 do
+		world.place_node({x=x,y=50,z=0}, "technic:hv_cable", player)
 	end
 	for x, name in ipairs(machines) do
-		world.place_node({x=x,y=1,z=0}, name, player)
+		world.place_node({x=x,y=51,z=0}, name, player)
 	end
 
 	-- Helper function to execute netowork
@@ -72,33 +68,33 @@ describe("HV machine network", function()
 		spy.on(technic, "network_run")
 		run_network(60)
 		assert.spy(technic.network_run).called(60)
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		assert.not_nil(technic.networks[id])
 		assert.gt(technic.networks[id].supply, 0)
 	end)
 
 	it("kills network when switching station disappear", function()
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		assert.not_nil(technic.networks[id])
 		-- Remove switching station and execute globalstep
-		world.set_node({x=100,y=1,z=0}, {name="air"})
+		world.set_node({x=0,y=51,z=0}, {name="air"})
 		mineunit:execute_globalstep(1)
 		-- Network should be gone
 		assert.is_nil(technic.networks[id])
 		-- Build new switching station to restore network
-		world.place_node({x=100,y=1,z=0}, {name="technic:switching_station"})
+		world.place_node({x=0,y=51,z=0}, {name="technic:switching_station"})
 		mineunit:execute_globalstep(1)
 		assert.not_nil(technic.networks[id])
 	end)
 
 	it("charges battery box", function()
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		local net = technic.networks[id]
 		assert.gt(net.battery_charge, 1000)
 	end)
 
 	it("smelts ores", function()
-		local machine_pos = {x=8,y=1,z=0}
+		local machine_pos = {x=3,y=51,z=0}
 		place_itemstack(machine_pos, "technic:lead_lump 99")
 		run_network(60)
 		-- Check results, at least 10 items processed and results in correct stuff
@@ -108,7 +104,7 @@ describe("HV machine network", function()
 	end)
 
 	it("grinds ores", function()
-		local machine_pos = {x=9,y=1,z=0}
+		local machine_pos = {x=4,y=51,z=0}
 		place_itemstack(machine_pos, "technic:lead_lump 99")
 		run_network(60)
 		-- Check results, at least 10 items processed and results in correct stuff

--- a/technic/spec/lv_network_spec.lua
+++ b/technic/spec/lv_network_spec.lua
@@ -19,12 +19,6 @@ describe("LV machine network", function()
 	world.set_default_node("air")
 
 	local machines = {
-		"technic:lv_generator",
-		"technic:geothermal",
-		"technic:solar_panel",
-		"technic:lv_solar_array",
-		"technic:lv_solar_array",
-		"technic:lv_solar_array",
 		"technic:lv_battery_box0",
 		"technic:lv_electric_furnace",
 		"technic:lv_extractor",
@@ -34,22 +28,26 @@ describe("LV machine network", function()
 		"technic:lv_led",
 		"technic:lv_lamp",
 		"technic:water_mill",
+		"technic:lv_generator",
+		"technic:geothermal",
+		"technic:solar_panel",
+		"technic:lv_solar_array",
 	}
 
 	world.clear()
-	world.place_node({x=100,y=1,z=0}, "technic:switching_station", player)
-	for x = 1, 100 do
-		world.place_node({x=x,y=0,z=0}, "technic:lv_cable", player)
+	world.place_node({x=0,y=51,z=0}, "technic:switching_station", player)
+	for x = 0, 15 do
+		world.place_node({x=x,y=50,z=0}, "technic:lv_cable", player)
 	end
 	for x, name in ipairs(machines) do
-		world.place_node({x=x,y=1,z=0}, name, player)
+		world.place_node({x=x,y=51,z=0}, name, player)
 	end
 
 	-- Helper to destroy nodes in test world returning list of removed nodes indexed by coordinates
 	local function remove_nodes(nodes)
 		local removed = {}
-		for x = 1, 100 do
-			local pos = {x=x,y=1,z=0}
+		for x = 0, 15 do
+			local pos = {x=x,y=51,z=0}
 			local node = minetest.get_node(pos)
 			if nodes[node.name] then
 				removed[pos] = node
@@ -96,33 +94,33 @@ describe("LV machine network", function()
 		spy.on(technic, "network_run")
 		run_network(60)
 		assert.spy(technic.network_run).called(60)
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		assert.not_nil(technic.networks[id])
 		assert.gt(technic.networks[id].supply, 0)
 	end)
 
 	it("kills network when switching station disappear", function()
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		assert.not_nil(technic.networks[id])
 		-- Remove switching station and execute globalstep
-		world.remove_node({x=100,y=1,z=0})
+		world.remove_node({x=0,y=51,z=0})
 		run_network()
 		-- Network should be gone
 		assert.is_nil(technic.networks[id])
 		-- Build new switching station to restore network
-		world.place_node({x=100,y=1,z=0}, {name="technic:switching_station"})
+		world.place_node({x=0,y=51,z=0}, {name="technic:switching_station"})
 		run_network()
 		assert.not_nil(technic.networks[id])
 	end)
 
 	it("charges battery box", function()
-		local id = technic.pos2network({x=100,y=0,z=0})
+		local id = technic.pos2network({x=0,y=50,z=0})
 		local net = technic.networks[id]
 		assert.gt(net.battery_charge, 1000)
 	end)
 
 	it("smelts ores", function()
-		local machine_pos = {x=8,y=1,z=0}
+		local machine_pos = {x=2,y=51,z=0}
 		place_itemstack(machine_pos, "technic:lead_lump 99")
 		run_network(60)
 		-- Check results, at least 10 items processed and results in correct stuff
@@ -132,7 +130,7 @@ describe("LV machine network", function()
 	end)
 
 	it("grinds ores", function()
-		local machine_pos = {x=10,y=1,z=0}
+		local machine_pos = {x=4,y=51,z=0}
 		place_itemstack(machine_pos, "technic:lead_lump 99")
 		run_network(60)
 		-- Check results, at least 10 items processed and results in correct stuff
@@ -142,7 +140,7 @@ describe("LV machine network", function()
 	end)
 
 	it("comperess sand", function()
-		local machine_pos = {x=12,y=1,z=0}
+		local machine_pos = {x=6,y=51,z=0}
 		place_itemstack(machine_pos, "default:sand 99")
 		run_network(60)
 		-- Check results, at least 10 items processed and results in correct stuff
@@ -152,10 +150,10 @@ describe("LV machine network", function()
 	end)
 
 	it("cuts power when generators disappear", function()
-		place_itemstack({x=8,y=1,z=0}, "technic:lead_lump 99")
-		place_itemstack({x=10,y=1,z=0}, "technic:lead_lump 99")
-		place_itemstack({x=12,y=1,z=0}, "default:sand 99")
-		local id = technic.pos2network({x=100,y=0,z=0})
+		place_itemstack({x=2,y=51,z=0}, "technic:lead_lump 99")
+		place_itemstack({x=4,y=51,z=0}, "technic:lead_lump 99")
+		place_itemstack({x=6,y=51,z=0}, "default:sand 99")
+		local id = technic.pos2network({x=0,y=50,z=0})
 		assert.not_nil(technic.networks[id])
 
 		-- Remove generators and run network 60 times

--- a/technic_chests/README.md
+++ b/technic_chests/README.md
@@ -1,6 +1,10 @@
 Technic chests
 ==============
 
+![luacheck](https://github.com/mt-mods/technic/workflows/luacheck/badge.svg)
+![mineunit](https://github.com/mt-mods/technic/workflows/mineunit/badge.svg)
+![](https://byob.yarr.is/mt-mods/technic/coverage-chests)
+
 License
 -------
 


### PR DESCRIPTION
Implementing #249 reduces solar arrays and moves test networks to y 50.

Makes test execution about 20% faster (tested with code coverage collection, ran both 5x with almost same results between runs).
Comparing here with last merged PR and this one:
11.70723 seconds vs 9.231875 seconds

Maybe also update other test related stuff here so draft for now...