### PR TITLE
Compatibility for technic_set_charge/technic_get_charge

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -52,14 +52,24 @@ Power tool API
 	* Registers power tool adding required fields, otherwise same as `minetest.register_tool(itemname, definition)`.
 	* For regular power tools you only want to change `max_charge` and leave other fields unset (defaults).
 	* Special fields for `definition`:
-		* `max_charge` Number, maximum charge for tool. Defaults to `10000` which is same as RE battery.
+		* `technic_max_charge` Number, maximum charge for tool. Defaults to `10000` which is same as RE battery.
 		* `on_refill` Function to refill charge completely. Default is to set maximum charge for tool.
 		* `wear_represents` Customize wear indicator instead of using charge level. Default is `"technic_RE_charge"`.
 		* `tool_capabilities` See Minetest documentation. Default is `{ punch_attack_uses = 0 }`.
+		* `technic_get_charge = function(itemstack) ...`:
+			* Callback will be used to get itemstack charge and max\_charge.
+			* Have to return values `charge, max_charge`.
+			* Etc. `local charge, maxcharge = itemdef.technic_get_charge(itemstack)`.
+			* Defaults to `technic.get_RE_charge` which handles tool wear and charge values.
+		* `technic_set_charge = function(itemstack, charge) ...`:
+			* Callback will be used to set itemstack charge.
+			* Defaults to `technic.set_RE_charge` which handles tool wear and charge values.
 * `technic.get_RE_charge(itemstack)`
-	* Returns current charge level of tool
+	* Returns current charge level of tool.
+	* For tool charger mods it is recommended to use `<tooldef>.technic_get_charge(stack)` instead.
 * `technic.set_RE_charge(itemstack, charge)`
 	* Sets tool charge level.
+	* For tool charger mods it is recommended to use `<tooldef>.technic_set_charge(stack, charge)` instead.
 * `technic.use_RE_charge(itemstack, charge)`
 	* Attempt to use charge and return `true`/`false` indicating success.
 	* Always succeeds without checking charge level if creative is enabled.

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -73,13 +73,13 @@ function technic.set_RE_charge(stack, charge)
 end
 
 function technic.get_RE_charge(stack)
-	local wear_factor = stack:get_definition().technic_wear_factor
-	if wear_factor then
+	local def = stack:get_definition()
+	if def.technic_wear_factor then
 		local wear = stack:get_wear()
-		return math.floor((wear > 0 and 65536 - wear or 0) / wear_factor + 0.5)
+		return (wear > 0 and math.floor((65536 - wear) / def.technic_wear_factor + 0.5) or 0), def.technic_max_charge
 	end
 	minetest.log("warning", "technic.get_RE_charge item not registered as power tool: "..stack:get_name())
-	return 0
+	return 0, 0
 end
 
 function technic.use_RE_charge(stack, amount)

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -222,7 +222,7 @@ function technic.register_battery_box(nodename, data)
 			tooldef.technic_set_charge(toolstack, charge)
 			inv:set_stack("src", 1, toolstack)
 		end
-		return batt_charge - charge_step, (charge == def.technic_max_charge)
+		return batt_charge - charge_step, (charge == tooldef.technic_max_charge)
 	end
 
 	local function discharge_tools(meta, batt_charge, charge_step, batt_max_charge)

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -194,55 +194,56 @@ function technic.register_battery_box(nodename, data)
 		end
 		-- Get itemstack and check if it is registered tool
 		local toolstack = inventory:get_stack(listname, 1)
-		local toolname = toolstack:get_name()
-		if technic.power_tools[toolname] == nil then
+		local tooldef = toolstack:get_definition()
+		if not tooldef.technic_max_charge then
 			return
 		end
-		-- Load and check tool metadata
-		return toolstack, technic.power_tools[toolname]
+		return toolstack, tooldef
 	end
 
 	local function charge_tools(meta, batt_charge, charge_step)
 		-- Get tool metadata
 		local inv = meta:get_inventory()
-		local toolstack, max_charge = get_tool(inv, "src")
+		local toolstack, tooldef = get_tool(inv, "src")
 		if not toolstack then
 			return batt_charge, false
 		end
 		-- Do the charging
-		local charge = technic.get_RE_charge(toolstack)
-		if charge >= max_charge then
+		local charge = tooldef.technic_get_charge(toolstack)
+		if charge >= tooldef.technic_max_charge then
 			return batt_charge, true
 		elseif batt_charge <= 0 then
 			return batt_charge, false
 		end
 		local oldcharge = charge
-		charge_step = math.min(math.min(charge_step, batt_charge), max_charge - charge)
+		charge_step = math.min(charge_step, batt_charge, tooldef.technic_max_charge - charge)
 		charge = charge + charge_step
 		if charge ~= oldcharge then
-			technic.set_RE_charge(toolstack, charge)
+			tooldef.technic_set_charge(toolstack, charge)
 			inv:set_stack("src", 1, toolstack)
 		end
-		return batt_charge - charge_step, (charge == max_charge)
+		return batt_charge - charge_step, (charge == def.technic_max_charge)
 	end
 
 	local function discharge_tools(meta, batt_charge, charge_step, batt_max_charge)
 		-- Get tool metadata
 		local inv = meta:get_inventory()
-		local toolstack = get_tool(inv, "dst")
-		if not toolstack then return batt_charge, false end
+		local toolstack, tooldef = get_tool(inv, "dst")
+		if not toolstack then
+			return batt_charge, false
+		end
 		-- Do the discharging
-		local charge = technic.get_RE_charge(toolstack)
+		local charge = tooldef.technic_get_charge(toolstack)
 		if charge <= 0 then
 			return batt_charge, true
 		elseif batt_charge >= batt_max_charge then
 			return batt_charge, false
 		end
 		local oldcharge = charge
-		charge_step = math.min(math.min(charge_step, batt_max_charge - batt_charge), charge)
+		charge_step = math.min(charge_step, batt_max_charge - batt_charge, charge)
 		charge = charge - charge_step
 		if charge ~= oldcharge then
-			technic.set_RE_charge(toolstack, charge)
+			tooldef.technic_set_charge(toolstack, charge)
 			inv:set_stack("dst", 1, toolstack)
 		end
 		return batt_charge + charge_step, (charge == 0)

--- a/technic/register.lua
+++ b/technic/register.lua
@@ -34,9 +34,11 @@ function technic.register_power_tool(itemname, itemdef)
 	itemdef.wear_represents = itemdef.wear_represents or "technic_RE_charge"
 	itemdef.technic_max_charge = max_charge
 	itemdef.technic_wear_factor = 65535 / max_charge
+	itemdef.technic_get_charge = itemdef.technic_get_charge or technic.get_RE_charge
+	itemdef.technic_set_charge = itemdef.technic_set_charge or technic.set_RE_charge
 	itemdef.on_refill = itemdef.on_refill or function(stack)
-		-- This is always using originally defined max_charge even if stack somehow changed to another
-		technic.set_RE_charge(stack, max_charge)
+		local def = stack:get_definition()
+		def.technic_set_charge(stack, def.technic_max_charge)
 		return stack
 	end
 	itemdef.tool_capabilities = itemdef.tool_capabilities or { punch_attack_uses = 0 }


### PR DESCRIPTION
Implements [minetest-mods/technic#600](https://github.com/minetest-mods/technic/pull/600) for [mt-mods/technic#272](https://github.com/mt-mods/technic/issues/272)

This one without changing `technic.get_RE_charge` / `technic.set_RE_charge`, keeps new power tool definition methods independent.

Should also offer better compatibility with original Technic mod.

See https://github.com/mt-mods/technic/pull/273#issuecomment-1153178436

Basically this makes `technic.get_RE_charge` and `technic.set_RE_charge` very tool specific while `<itemdef>.technic_get_charge` and `<itemdef>.technic_set_charge` will be overridable functions pointing to `technic.get_RE_charge` and `technic.set_RE_charge` by default.

Other option #273 makes `technic.get_RE_charge` and `technic.set_RE_charge` universally compatible while `<itemdef>.technic_get_charge` and `<itemdef>.technic_set_charge` would be overridable functions not defined by default and never calling through `technic.get_RE_charge` or `technic.set_RE_charge`.