### PR TITLE
Tool compatibility shims

### DIFF
--- a/technic/machines/compat/tools.lua
+++ b/technic/machines/compat/tools.lua
@@ -1,40 +1,113 @@
+--
+-- This allows using old style technic.register_power_tool tool registration function.
+--
+-- To make tool fully compatible replace `minetest.register_tool` with `technic.register_power_tool`
+-- and add `technic_max_charge` field for tool definition.
+-- Fields `wear_represents` and `on_refill` can be removed if using defaults.
+--
+-- Does not offer compatibility for charger mods: mods that charge or discharge registered power tools.
+-- Compatibility for those can be achieved by using `<tooldef>.technic_get_charge` / `<tooldef>.technic_set_charge`.
+--
 
--- This wont give full compatibility but allows using old style technic.register_power_tool tool registration function.
--- Tools still have to read charge value using technic.get_RE_charge, allows easier compatibility with official Technic
--- mod for some tools: a lot less changes required for compatibility but tool will keep some unnecessary meatadata.
---
--- To make tool fully compatible replace minetest.register_tool with technic.register_power_tool and add `max_charge`
--- field for tool definition. Fields `wear_represents` and `on_refill` can also be removed if using defaults.
---
-local register_power_tool = technic.register_power_tool
-function technic.register_power_tool(itemname, itemdef)
-	if type(itemdef) == "number" then
-		minetest.log("warning", "Deprecated technic.register_power_tool use. Setting max_charge for "..itemname)
-		technic.power_tools[itemname] = itemdef
-		minetest.register_on_mods_loaded(function()
-			minetest.log("warning", "Deprecated technic.register_power_tool use. Ensuring fields for "..itemname)
-			local redef = minetest.registered_items[itemname]
-			if redef and redef.wear_represents == "technic_RE_charge" and not redef.on_refill then
-				-- Override power tools that called register_power_tool but do not have on_refill function defined
-				local max_charge = itemdef
-				minetest.override_item(itemname, {
-					on_refill = function(stack)
-						technic.set_RE_charge(stack, max_charge)
-						return stack
-					end,
-					technic_max_charge = max_charge,
-					technic_wear_factor = 65535 / max_charge,
-				})
-				minetest.log("warning", "Updated on_refill and max_charge for "..itemname)
-			end
-		end)
-	else
-		return register_power_tool(itemname, itemdef)
+local function compat_set_RE_wear(stack, charge)
+	local def = stack:get_definition()
+	if def.technic_wear_factor then
+		local wear = math.floor(charge * def.technic_wear_factor + 0.5)
+		stack:set_wear(wear > 0 and 65536 - wear or 0)
 	end
 end
 
--- Alias set set_RE_wear, many tools calls this to set wear value which is also handled by set_RE_charge
+local function compat_technic_get_charge(stack)
+	local def = stack:get_definition()
+	if def.technic_max_charge then
+		local legacy_fields = minetest.deserialize(stack:get_meta():get_string("")) or {}
+		return legacy_fields.charge or 0, def.technic_max_charge
+	end
+	return 0, 0
+end
+
+local function compat_technic_set_charge(stack, charge)
+	compat_set_RE_wear(stack, charge)
+	local meta = stack:get_meta()
+	local legacy_fields = minetest.deserialize(meta:get_string("")) or {}
+	legacy_fields.charge = charge
+	meta:set_string("", minetest.serialize(legacy_fields))
+end
+
+-- This attempts to find out if mod is aware of technic.plus version property and marks mod as `plus_aware` if
+-- it tries to read `technic.plus` value. Marked tools wont receive automatic metadata compatibility functions.
+local plus_aware = {}
+do
+	local original_mt = getmetatable(technic)
+	local mt = original_mt and table.copy(original_mt) or {}
+	local mt_index = mt.__index or rawget
+	local plus = technic.plus
+	rawset(technic, "plus", nil)
+
+	-- Extend `__index` lookup function for `technic` to collect mod names that are reading `technic.plus` property
+	function mt:__index(key)
+		if key == "plus" then
+			local modname = minetest.get_current_modname()
+			if modname then
+				plus_aware[modname] = true
+			end
+			return plus
+		end
+		return mt_index(self, key)
+	end
+	setmetatable(technic, mt)
+
+	-- Restore version and metatable, this must happen after handling register_on_mods_loaded callbacks
+	minetest.after(0, function()
+		rawset(technic, "plus", plus)
+		setmetatable(technic, original_mt)
+	end)
+end
+
+-- Override `technic.register_power_tool` to handle old style registration that was only setting max charge value.
+local register_power_tool = technic.register_power_tool
+function technic.register_power_tool(itemname, def_or_max_charge)
+	if type(def_or_max_charge) == "number" then
+		minetest.log("warning", "Deprecated technic.register_power_tool use. Setting max_charge for "..itemname)
+		technic.power_tools[itemname] = def_or_max_charge
+		minetest.register_on_mods_loaded(function()
+			minetest.log("warning", "Deprecated technic.register_power_tool use. Ensuring fields for "..itemname)
+			local redef = minetest.registered_items[itemname]
+			if redef and redef.wear_represents == "technic_RE_charge" then
+				-- Override power tools that called register_power_tool but do not have on_refill function defined
+				local overrides = {
+					technic_max_charge = def_or_max_charge,
+					technic_wear_factor = 65535 / def_or_max_charge,
+					technic_get_charge = technic.get_RE_charge,
+					technic_set_charge = technic.set_RE_charge,
+					on_refill = function(stack)
+						local tooldef = stack:get_definition()
+						tooldef.technic_set_charge(stack, def_or_max_charge)
+						return stack
+					end,
+				}
+				-- Add legacy meta handlers if mod did not attempt to read technic.plus value
+				local modname = itemname:match(":?(.+):")
+				if plus_aware[modname] then
+					minetest.log("warning", "Mod "..modname.." seems to be aware of technic.plus but "..
+						itemname.." is still using deprecated registration, skipping meta charge compatibility.")
+				elseif not redef.technic_get_charge and not redef.technic_set_charge then
+					overrides.technic_get_charge = compat_technic_get_charge
+					overrides.technic_set_charge = compat_technic_set_charge
+					minetest.log("warning", "Using metadata charge values for "..itemname)
+				end
+				-- Override tool definition with added / new values
+				minetest.override_item(itemname, overrides)
+				minetest.log("warning", "Updated legacy Technic power tool definition for "..itemname)
+			end
+		end)
+	else
+		return register_power_tool(itemname, def_or_max_charge)
+	end
+end
+
+-- Same as `technic.set_RE_charge` but without calling through `itemdef.technic_set_charge`.
 function technic.set_RE_wear(stack, charge)
 	minetest.log("warning", "Use of deprecated function technic.set_RE_wear with stack: "..stack:get_name())
-	technic.set_RE_charge(stack, charge)
+	compat_set_RE_wear(stack, charge)
 end

--- a/technic/machines/compat/tools.lua
+++ b/technic/machines/compat/tools.lua
@@ -78,8 +78,6 @@ function technic.register_power_tool(itemname, def_or_max_charge)
 				local overrides = {
 					technic_max_charge = def_or_max_charge,
 					technic_wear_factor = 65535 / def_or_max_charge,
-					technic_get_charge = technic.get_RE_charge,
-					technic_set_charge = technic.set_RE_charge,
 					on_refill = function(stack)
 						local tooldef = stack:get_definition()
 						tooldef.technic_set_charge(stack, def_or_max_charge)
@@ -89,6 +87,8 @@ function technic.register_power_tool(itemname, def_or_max_charge)
 				-- Add legacy meta handlers if mod did not attempt to read technic.plus value
 				local modname = itemname:match(":?(.+):")
 				if plus_aware[modname] then
+					overrides.technic_get_charge = redef.technic_get_charge or technic.get_RE_charge
+					overrides.technic_set_charge = redef.technic_set_charge or technic.set_RE_charge
 					minetest.log("warning", "Mod "..modname.." seems to be aware of technic.plus but "..
 						itemname.." is still using deprecated registration, skipping meta charge compatibility.")
 				elseif not redef.technic_get_charge and not redef.technic_set_charge then
@@ -99,6 +99,9 @@ function technic.register_power_tool(itemname, def_or_max_charge)
 				-- Override tool definition with added / new values
 				minetest.override_item(itemname, overrides)
 				minetest.log("warning", "Updated legacy Technic power tool definition for "..itemname)
+			else
+				minetest.log("error", "Technic compatibility overrides skipped for "..itemname..", charging might "..
+					'cause crash. Upgrading to technic.register_power_tool("'..itemname..'", {itemdef}) recommended.')
 			end
 		end)
 	else

--- a/technic/spec/fixtures/old_powertool.lua
+++ b/technic/spec/fixtures/old_powertool.lua
@@ -1,0 +1,81 @@
+
+local function doregister(modname, callback)
+	mineunit:set_modpath(modname, "spec/fixtures")
+	mineunit:set_current_modname(modname)
+	callback()
+	mineunit:restore_current_modname()
+end
+
+local MAX_CHARGE = 65536
+local USE_CHARGE = 1000
+
+-- No updates for compatibility
+doregister("oldlegacy", function()
+	technic.register_power_tool("oldlegacy:powertool", MAX_CHARGE)
+	minetest.register_tool("oldlegacy:powertool", {
+		description = "Powertool",
+		inventory_image = "powertool.png",
+		stack_max = 1,
+		wear_represents = "technic_RE_charge",
+		on_refill = technic.refill_RE_charge,
+		on_use = function(itemstack, user, pointed_thing)
+			local meta = minetest.deserialize(itemstack:get_meta():get_string(""))
+			if not meta or not meta.charge or meta.charge < USE_CHARGE then
+				return
+			end
+			meta.charge = meta.charge - USE_CHARGE
+			technic.set_RE_wear(itemstack, meta.charge, MAX_CHARGE)
+			itemstack:get_meta():set_string("", minetest.serialize(meta))
+			return itemstack
+		end,
+	})
+end)
+
+-- Previously suggested minimal compatibility workaround added
+doregister("oldminimal", function()
+	technic.register_power_tool("oldminimal:powertool", MAX_CHARGE)
+	minetest.register_tool("oldminimal:powertool", {
+		description = "Powertool",
+		inventory_image = "powertool.png",
+		stack_max = 1,
+		wear_represents = "technic_RE_charge",
+		on_refill = technic.refill_RE_charge,
+		on_use = function(itemstack, user, pointed_thing)
+			local meta = technic.plus and { charge = technic.get_RE_charge(itemstack) }
+				or error("oldminimal:powertool wrong charge handler called")
+			if not meta or not meta.charge or meta.charge < USE_CHARGE then
+				return
+			end
+			meta.charge = meta.charge - USE_CHARGE
+			technic.set_RE_wear(itemstack, meta.charge, MAX_CHARGE)
+			itemstack:get_meta():set_string("", minetest.serialize(meta))
+			return itemstack
+		end,
+	})
+end)
+
+-- Halfway there, checking for technic.plus and deciding charge handling based on that
+doregister("oldhalfway", function()
+	local get_charge = technic.plus and technic.get_RE_charge or function()
+		error("Wrong get_charge handler called for oldhalfway:powertool")
+	end
+	local set_charge = technic.plus and technic.set_RE_charge or function()
+		error("Wrong set_charge handler called for oldhalfway:powertool")
+	end
+	technic.register_power_tool("oldhalfway:powertool", MAX_CHARGE)
+	minetest.register_tool("oldhalfway:powertool", {
+		description = "Powertool",
+		inventory_image = "powertool.png",
+		stack_max = 1,
+		wear_represents = "technic_RE_charge",
+		on_refill = technic.refill_RE_charge,
+		on_use = function(itemstack, user, pointed_thing)
+			local charge = get_charge(itemstack)
+			if not charge or charge < USE_CHARGE then
+				return
+			end
+			set_charge(itemstack, charge - USE_CHARGE)
+			return itemstack
+		end,
+	})
+end)

--- a/technic/spec/tools_compatibility_spec.lua
+++ b/technic/spec/tools_compatibility_spec.lua
@@ -1,0 +1,167 @@
+require("mineunit")
+--[[
+	Technic tool regression tests.
+	Execute mineunit at technic source directory.
+--]]
+
+-- Load complete technic mod
+fixture("technic")
+sourcefile("init")
+
+describe("Technic power tool compatibility", function()
+
+	fixture("old_powertool")
+
+	world.set_default_node("air")
+
+	-- HV battery box and some HV solar arrays for charging
+	local BB_Charge_POS = {x=0,y=51,z=0}
+	local BB_Discharge_POS = {x=0,y=51,z=2}
+	world.layout({
+		-- Network with generators for charging tools in battery box
+		{BB_Charge_POS, "technic:hv_battery_box0"},
+		{{x=1,y=51,z=0}, "technic:switching_station"},
+		{{{x=2,y=51,z=0},{x=10,y=51,z=0}}, "technic:solar_array_hv"},
+		{{{x=0,y=50,z=0},{x=10,y=50,z=0}}, "technic:hv_cable"},
+		-- Network without generators for discharging tools in battery box
+		{BB_Discharge_POS, "technic:hv_battery_box0"},
+		{{x=1,y=51,z=2}, "technic:switching_station"},
+		{{{x=0,y=50,z=2},{x=1,y=50,z=2}}, "technic:hv_cable"},
+	})
+
+	-- Some helpers to make stack access simpler
+	local player = Player("SX")
+	local charge_inv = minetest.get_meta(BB_Charge_POS):get_inventory()
+	local discharge_inv = minetest.get_meta(BB_Discharge_POS):get_inventory()
+	local function set_charge_stack(stack) charge_inv:set_stack("src", 1, stack) end
+	local function get_charge_stack() return charge_inv:get_stack("src", 1) end
+	local function set_discharge_stack(stack) discharge_inv:set_stack("dst", 1, stack) end
+	local function get_discharge_stack() return discharge_inv:get_stack("dst", 1) end
+	local function set_player_stack(stack) return player:get_inventory():set_stack("main", 1, stack) end
+	local function get_player_stack() return player:get_inventory():get_stack("main", 1) end
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	local function test(itemname, callback)
+		describe(itemname, function()
+
+			local itemdef = minetest.registered_items[itemname]
+
+			setup(function()
+				mineunit:execute_on_joinplayer(player)
+			end)
+
+			teardown(function()
+				mineunit:execute_on_leaveplayer(player)
+			end)
+
+			before_each(function()
+				set_charge_stack(ItemStack())
+				set_discharge_stack(ItemStack())
+			end)
+
+			it("is registered", function()
+				assert.is_hashed(itemdef)
+				assert.is_function(itemdef.on_use)
+				assert.is_function(itemdef.on_refill)
+				assert.equals("technic_RE_charge", itemdef.wear_represents)
+				assert.is_number(itemdef.technic_max_charge)
+				assert.gt(itemdef.technic_max_charge, 0)
+			end)
+
+			it("can be used (zero charge)", function()
+				set_player_stack(itemname)
+				spy.on(itemdef, "on_use")
+				player:do_use(player:get_pos())
+				assert.spy(itemdef.on_use).called(1)
+			end)
+
+			it("itemdef.technic_get_charge works (zero charge)", function()
+				assert.equals(0, itemdef.technic_get_charge(ItemStack(itemname)))
+			end)
+
+			it("itemdef.technic_set_charge works (zero charge -> 123)", function()
+				local stack = ItemStack(itemname)
+				itemdef.technic_set_charge(stack, 123)
+				assert.equals(123, itemdef.technic_get_charge(stack))
+			end)
+
+			it("can be used (minimum charge)", function()
+				-- Add partially charged tool to player inventory
+				local stack = ItemStack(itemname)
+				itemdef.technic_set_charge(stack, 1000)
+				set_player_stack(stack)
+				spy.on(itemdef, "on_use")
+				-- Use tool twice
+				player:do_use(player:get_pos())
+				player:do_use(player:get_pos())
+				-- and verify results
+				assert.spy(itemdef.on_use).called(2)
+				assert.equals(0, itemdef.technic_get_charge(get_player_stack()))
+			end)
+
+			it("can be used (minimum charge + 1)", function()
+				-- Add partially charged tool to player inventory
+				local stack = ItemStack(itemname)
+				itemdef.technic_set_charge(stack, 1001)
+				set_player_stack(stack)
+				spy.on(itemdef, "on_use")
+				-- Use tool twice
+				player:do_use(player:get_pos())
+				player:do_use(player:get_pos())
+				-- and verify results
+				assert.spy(itemdef.on_use).called(2)
+				assert.equals(1, itemdef.technic_get_charge(get_player_stack()))
+			end)
+
+			it("can be charged", function()
+				-- Stack without charge to battery box charge slot
+				local stack = ItemStack(itemname)
+				itemdef.technic_set_charge(stack, 0)
+				assert.equals(0, stack:get_wear())
+				set_charge_stack(stack)
+
+				-- Verify that item charge is empty and charge in battery box for 8 seconds
+				assert.equals(0, itemdef.technic_get_charge(get_charge_stack()))
+				for i=1, 8 do
+					mineunit:execute_globalstep(1)
+				end
+
+				-- Check charge / wear values
+				assert.equals(itemdef.technic_max_charge, itemdef.technic_get_charge(get_charge_stack()))
+				assert.equals(1, get_charge_stack():get_wear())
+			end)
+
+			it("can be discharged", function()
+				-- Fully charged stack to battery box discharge slot
+				local stack = ItemStack(itemname)
+				itemdef.technic_set_charge(stack, itemdef.technic_max_charge)
+				assert.equals(1, stack:get_wear())
+				set_discharge_stack(stack)
+
+				-- Verify that item is fully charged and discharge in battery box for 2 seconds
+				assert.equals(itemdef.technic_max_charge, itemdef.technic_get_charge(get_discharge_stack()))
+				for i=1, 2 do
+					mineunit:execute_globalstep(1)
+				end
+
+				-- Take item from battery box and check charge / wear values
+				assert.equals(0, itemdef.technic_get_charge(get_discharge_stack()))
+				assert.equals(0, get_discharge_stack():get_wear())
+			end)
+
+			if callback then callback() end
+
+		end)
+
+	end
+
+	-- Register test set for tools using different registration and compatibility methods
+	test("oldlegacy:powertool")
+	test("oldminimal:powertool")
+	test("oldhalfway:powertool")
+
+end)

--- a/technic/spec/tools_spec.lua
+++ b/technic/spec/tools_spec.lua
@@ -43,8 +43,8 @@ describe("Technic power tool", function()
 	local discharge_inv = minetest.get_meta(BB_Discharge_POS):get_inventory()
 	local function set_charge_stack(stack) charge_inv:set_stack("src", 1, stack) end
 	local function get_charge_stack() return charge_inv:get_stack("src", 1) end
-	local function set_discharge_stack(stack) discharge_inv:set_stack("src", 1, stack) end
-	local function get_discharge_stack() return discharge_inv:get_stack("src", 1) end
+	local function set_discharge_stack(stack) discharge_inv:set_stack("dst", 1, stack) end
+	local function get_discharge_stack() return discharge_inv:get_stack("dst", 1) end
 	local function set_player_stack(stack) return player:get_inventory():set_stack("main", 1, stack) end
 	local function get_player_stack() return player:get_inventory():get_stack("main", 1) end
 
@@ -346,7 +346,7 @@ describe("Technic power tool", function()
 
 			-- Verify that item charge is empty and charge in battery box for 30 seconds
 			assert.equals(0, technic.get_RE_charge(get_charge_stack()))
-			for i=0, 30 do
+			for i=1, 30 do
 				mineunit:execute_globalstep(1)
 			end
 
@@ -367,6 +367,22 @@ describe("Technic power tool", function()
 			assert.is_number(charge)
 			assert.gt(charge, 0)
 			assert.lt(charge, itemdef.technic_max_charge)
+		end)
+
+		it("can be discharged", function()
+			-- Put item from player inventory to battery box src inventory
+			player:do_metadata_inventory_put(BB_Discharge_POS, "dst", 1)
+
+			-- Verify that item is charged and discharge in battery box for 3 seconds
+			assert.lt(itemdef.technic_max_charge / 2, technic.get_RE_charge(get_discharge_stack()))
+			for i=1, 3 do
+				mineunit:execute_globalstep(1)
+			end
+
+			-- Take item from battery box and check charge / wear values
+			player:do_metadata_inventory_take(BB_Discharge_POS, "dst", 1)
+			assert.gt(itemdef.technic_max_charge, 0)
+			assert.equals(0, technic.get_RE_charge(get_player_stack()))
 		end)
 
 	end)


### PR DESCRIPTION
Allows near complete compatibility with tools using previous API.
Adds simple test for power tool registration, use, charging and discharging with old style power tool definition.
Adds missing tool discharge test, simple "will-not-crash" test only checking if something happened.

Mostly old tool charger mods wont be fully compatible because there were no API for charging before #233 

New and updated tool charger mods should be made compatible with minetest-mods Technic using newly added methods:
`<itemdef>.technic_get_charge` and `<itemdef>.technic_set_charge` because those were added to minetest-mods Technic and both mostly compatible with mt-mods Technic.

Link PR #275 which is why at least `<itemdef>.technic_get_charge` and `<itemdef>.technic_set_charge` are needed as old registration wont add those and therefore can cause crash when trying to get/set tool charge.