### PR TITLE
add `5.6.1` engine to test matrix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ENGINE_VERSION: [5.3.0, 5.4.0, 5.5.0, 5.6.1, latest]
+        ENGINE_VERSION: [5.3.0, 5.6.1, latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ENGINE_VERSION: [5.3.0, 5.4.0, 5.5.0, latest]
+        ENGINE_VERSION: [5.3.0, 5.4.0, 5.5.0, 5.6.1, latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
adds `5.6.1` to the engine test matrix

maybe we should drop a few versions if this piles up :thinking: 