### PR TITLE
Use `minetest.load_area` everywhere

### DIFF
--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -101,16 +101,10 @@ function technic.use_RE_charge(stack, amount)
 	return true
 end
 
--- If the node is loaded, returns it. If it isn't loaded, load it and return nil.
+-- If the node is loaded, returns it. If it isn't loaded, load it.
 function technic.get_or_load_node(pos)
 	local node = minetest.get_node_or_nil(pos)
 	if node then return node end
-	minetest.load_area(pos)
-	return nil
-end
-
--- Loads the node and returns it.
-function technic.get_node_force(pos)
 	minetest.load_area(pos)
 	return minetest.get_node(pos)
 end

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -101,13 +101,18 @@ function technic.use_RE_charge(stack, amount)
 	return true
 end
 
--- If the node is loaded, returns it.  If it isn't loaded, load it and return nil.
+-- If the node is loaded, returns it. If it isn't loaded, load it and return nil.
 function technic.get_or_load_node(pos)
 	local node = minetest.get_node_or_nil(pos)
 	if node then return node end
-	local vm = VoxelManip()
-	local _, _ = vm:read_from_map(pos, pos)
+	minetest.load_area(pos)
 	return nil
+end
+
+-- Loads the node and returns it.
+function technic.get_node_force(pos)
+	minetest.load_area(pos)
+	return minetest.get_node(pos)
 end
 
 technic.tube_inject_item = pipeworks.tube_inject_item or function(pos, start_pos, velocity, item)

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -312,7 +312,7 @@ local function execute_dig(pos, node, meta, network)
 				meta:set_int("purge_on", 1)
 				break
 			end
-			local dig_node = technic.get_node_force(dig_pos)
+			local dig_node = technic.get_or_load_node(dig_pos)
 			if can_dig_node(dig_pos, dig_node.name, owner, digger) then
 				-- found something to dig, dig it and stop searching
 				minetest.remove_node(dig_pos)

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -56,7 +56,7 @@ end
 
 local function reset_quarry(pos)
 	local meta = minetest.get_meta(pos)
-	local node = technic.get_or_load_node(pos) or minetest.get_node(pos)
+	local node = minetest.get_node(pos)
 	meta:set_int("quarry_dir", node.param2)
 	meta:set_string("quarry_pos", minetest.pos_to_string(pos))
 	meta:set_string("dig_pos", "")
@@ -312,8 +312,7 @@ local function execute_dig(pos, node, meta, network)
 				meta:set_int("purge_on", 1)
 				break
 			end
-			minetest.load_area(dig_pos)
-			local dig_node = minetest.get_node(dig_pos)
+			local dig_node = technic.get_node_force(dig_pos)
 			if can_dig_node(dig_pos, dig_node.name, owner, digger) then
 				-- found something to dig, dig it and stop searching
 				minetest.remove_node(dig_pos)

--- a/technic/machines/network.lua
+++ b/technic/machines/network.lua
@@ -415,7 +415,7 @@ end
 
 -- Generic function to add found connected nodes to the right classification array
 local function add_network_node(network, pos, machines)
-	local name = technic.get_node_force(pos).name
+	local name = technic.get_or_load_node(pos).name
 
 	if technic.get_cable_tier(name) == network.tier then
 		add_cable_node(pos, network)

--- a/technic/machines/network.lua
+++ b/technic/machines/network.lua
@@ -78,12 +78,12 @@ function technic.activate_network(network_id, timeout)
 	end
 end
 
-function technic.sw_pos2tier(pos, use_vm)
+function technic.sw_pos2tier(pos, load_node)
 	-- Get cable tier for switching station or nil if no cable
-	-- use_vm true to use VoxelManip to load node
+	-- load_node true to use minetest.load_area to load node
 	local cable_pos = {x=pos.x,y=pos.y-1,z=pos.z}
-	if use_vm then
-		technic.get_or_load_node(cable_pos)
+	if load_node then
+		minetest.load_area(cable_pos)
 	end
 	return technic.get_cable_tier(minetest.get_node(cable_pos).name)
 end
@@ -415,8 +415,7 @@ end
 
 -- Generic function to add found connected nodes to the right classification array
 local function add_network_node(network, pos, machines)
-	technic.get_or_load_node(pos)
-	local name = minetest.get_node(pos).name
+	local name = technic.get_node_force(pos).name
 
 	if technic.get_cable_tier(name) == network.tier then
 		add_cable_node(pos, network)
@@ -592,12 +591,8 @@ end)
 
 local function run_nodes(list, vm, run_stage, network)
 	for _, pos in ipairs(list) do
-		local node = minetest.get_node_or_nil(pos)
-		if not node then
-			vm:read_from_map(pos, pos)
-			node = minetest.get_node_or_nil(pos)
-		end
-		if node and node.name and node_technic_run[node.name] then
+		local node = technic.get_node_force(pos)
+		if node_technic_run[node.name] then
 			node_technic_run[node.name](pos, node, run_stage, network)
 		end
 	end

--- a/technic/machines/network.lua
+++ b/technic/machines/network.lua
@@ -591,8 +591,12 @@ end)
 
 local function run_nodes(list, vm, run_stage, network)
 	for _, pos in ipairs(list) do
-		local node = technic.get_node_force(pos)
-		if node_technic_run[node.name] then
+		local node = minetest.get_node_or_nil(pos)
+		if not node then
+			vm:read_from_map(pos, pos)
+			node = minetest.get_node_or_nil(pos)
+		end
+		if node and node.name and node_technic_run[node.name] then
 			node_technic_run[node.name](pos, node, run_stage, network)
 		end
 	end

--- a/technic/machines/register/solar_array.lua
+++ b/technic/machines/register/solar_array.lua
@@ -18,7 +18,7 @@ function technic.register_solar_array(nodename, data)
 		-- built below 0m
 		local pos1 = { y = pos.y + 1, x = pos.x, z = pos.z }
 
-		technic.get_or_load_node(pos1)
+		minetest.load_area(pos1)
 		local light = minetest.get_node_light(pos1, nil)
 		local time_of_day = minetest.get_timeofday()
 		local meta = minetest.get_meta(pos)

--- a/technic/spec/fixtures/network.lua
+++ b/technic/spec/fixtures/network.lua
@@ -15,7 +15,7 @@ _G.technic = {}
 _G.technic.S = string.format
 _G.technic.modpath = "."
 _G.technic.getter = function(...) return "" end
-_G.technic.get_or_load_node = minetest.get_node
+_G.technic.get_node_force = minetest.get_node
 _G.technic.digilines = {
 	rules = {
 		-- digilines.rules.default

--- a/technic/spec/fixtures/network.lua
+++ b/technic/spec/fixtures/network.lua
@@ -15,7 +15,7 @@ _G.technic = {}
 _G.technic.S = string.format
 _G.technic.modpath = "."
 _G.technic.getter = function(...) return "" end
-_G.technic.get_node_force = minetest.get_node
+_G.technic.get_or_load_node = minetest.get_node
 _G.technic.digilines = {
 	rules = {
 		-- digilines.rules.default

--- a/technic/tools/multimeter.lua
+++ b/technic/tools/multimeter.lua
@@ -201,10 +201,10 @@ end
 
 local function remote_start_net(player, pos)
 	local sw_pos = {x=pos.x,y=pos.y+1,z=pos.z}
-	-- Try to load switch network node with VoxelManip
-	local sw_node = technic.get_or_load_node(sw_pos) or minetest.get_node(sw_pos)
+	-- Try to load switch network node
+	local sw_node = technic.get_node_force(sw_pos)
 	if sw_node.name ~= "technic:switching_station" then return "switchload" end
-	-- Try to load network node with VoxelManip
+	-- Try to load network node
 	local tier = technic.sw_pos2tier(sw_pos, true)
 	if not tier then return "cableload" end
 	-- Check protections

--- a/technic/tools/multimeter.lua
+++ b/technic/tools/multimeter.lua
@@ -202,7 +202,7 @@ end
 local function remote_start_net(player, pos)
 	local sw_pos = {x=pos.x,y=pos.y+1,z=pos.z}
 	-- Try to load switch network node
-	local sw_node = technic.get_node_force(sw_pos)
+	local sw_node = technic.get_or_load_node(sw_pos)
 	if sw_node.name ~= "technic:switching_station" then return "switchload" end
 	-- Try to load network node
 	local tier = technic.sw_pos2tier(sw_pos, true)


### PR DESCRIPTION
`technic.get_or_load_node` was mostly used to forcibly load nodes before getting them immediately after, so it makes sense to just provide a function that does that with less code.