### PR TITLE
Use node timers to spread out LV lamp updates

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -14,6 +14,7 @@ jobs:
       uses: mt-mods/mineunit-actions@master
       with:
         working-directory: ./technic
+        mineunit-args: --fetch-core 5.4.1 --engine-version 5.4.1
         badge-label: Test coverage
 
     - uses: RubbaBoy/BYOB@v1.2.0

--- a/technic/spec/fixtures/technic.lua
+++ b/technic/spec/fixtures/technic.lua
@@ -9,6 +9,9 @@ mineunit("protection")
 mineunit("common/after")
 mineunit("server")
 mineunit("voxelmanip")
+if mineunit:config("engine_version") ~= "mineunit" then
+	mineunit("game/voxelarea")
+end
 
 -- Load fixtures required by tests
 fixture("default")


### PR DESCRIPTION
The main problem with LV lamps is the cost of updating a 7x3x7 area (147 nodes) whenever they turn on or off. When multiple lamps are on the same network this puts an excessive load on the network, due to all the updates happening at the same time.

This PR delays the updates using node timers to happen over 0.2-2 seconds, and also reduces the continuous checks from every second to every 30-60 seconds. This significantly reduces the load on the network (only the lamp nodes are updated immediately), and also the server in general.

Should fix #216