### PR TITLE
use voxel manip for lv light illumination

### DIFF
--- a/technic/machines/LV/lamp.lua
+++ b/technic/machines/LV/lamp.lua
@@ -2,7 +2,6 @@
 -- LV Lamp - a powerful light source.
 -- Illuminates a 7x7x3(H) volume below itself with light bright as the sun.
 
-
 local S = technic.getter
 
 local desc = S("@1 Lamp", S("LV"))
@@ -10,7 +9,6 @@ local active_desc = S("@1 Active", desc)
 local unpowered_desc = S("@1 Unpowered", desc)
 local off_desc = S("@1 Off", desc)
 local demand = 50
-
 
 -- Invisible light source node used for illumination
 minetest.register_node("technic:dummy_light_source", {
@@ -29,46 +27,28 @@ minetest.register_node("technic:dummy_light_source", {
 	groups = {not_in_creative_inventory = 1}
 })
 
-local content_id_light_source = minetest.get_content_id("technic:dummy_light_source")
-local content_id_air = minetest.CONTENT_AIR
+local cid_light = minetest.get_content_id("technic:dummy_light_source")
+local cid_air = minetest.CONTENT_AIR
 
 local function illuminate(pos, active)
 	local pos1 = {x = pos.x - 3, y = pos.y - 3, z = pos.z - 3}
 	local pos2 = {x = pos.x + 3, y = pos.y - 1, z = pos.z + 3}
 
-	-- prepare vmanip, voxel-area and node-data
 	local vm = minetest.get_voxel_manip()
-	local e1, e2 = vm:read_from_map(pos1, pos2)
-	local va = VoxelArea:new({MinEdge = e1, MaxEdge = e2})
+	local va = VoxelArea(vm:read_from_map(pos1, pos2))
 	local node_data = vm:get_data()
 
-	-- replacements
-	local src_node, dst_node
-	if active then
-		src_node = content_id_air
-		dst_node = content_id_light_source
-	else
-		src_node = content_id_light_source
-		dst_node = content_id_air
-	end
+	local find_node = active and cid_air or cid_light
+	local set_node = active and cid_light or cid_air
 
-	-- dirty/changed flag
 	local dirty = false
-
-	for x=pos1.x, pos2.x do
-	for y=pos1.y, pos2.y do
-	for z=pos1.z, pos2.z do
-		local index = va:index(x,y,z)
-		if node_data[index] == src_node then
-			node_data[index] = dst_node
+	for i in va:iterp(pos1, pos2) do
+		if node_data[i] == find_node then
+			node_data[i] = set_node
 			dirty = true
 		end
 	end
-	end
-	end
-
 	if dirty then
-		-- write data back to map if changed
 		vm:set_data(node_data)
 		vm:write_to_map()
 	end

--- a/technic/machines/LV/lamp.lua
+++ b/technic/machines/LV/lamp.lua
@@ -35,7 +35,8 @@ local function illuminate(pos, active)
 	local pos2 = {x = pos.x + 3, y = pos.y - 1, z = pos.z + 3}
 
 	local vm = minetest.get_voxel_manip()
-	local va = VoxelArea(vm:read_from_map(pos1, pos2))
+	local emin, emax = vm:read_from_map(pos1, pos2)
+	local va = VoxelArea:new({MinEdge = emin, MaxEdge = emax})
 	local node_data = vm:get_data()
 
 	local find_node = active and cid_air or cid_light


### PR DESCRIPTION
As promised in #291

Timings:
* Old code: 10 to 20 ms
* New code: 2 to 8 ms

Test failures:
```
Failure → spec/lv_network_spec.lua @ 118
LV machine network charges battery box
spec/lv_network_spec.lua:121: Expected (number) 0 to be more than (number) 1000

Error → spec/lv_network_spec.lua @ 95
LV machine network executes network
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)

Error → spec/lv_network_spec.lua @ 104
LV machine network kills network when switching station disappear
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)

Error → spec/lv_network_spec.lua @ 124
LV machine network smelts ores
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)

Error → spec/lv_network_spec.lua @ 134
LV machine network grinds ores
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)

Error → spec/lv_network_spec.lua @ 144
LV machine network comperess sand
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)

Error → spec/lv_network_spec.lua @ 154
LV machine network cuts power when generators disappear
machines/LV/lamp.lua:42: attempt to index global 'VoxelArea' (a nil value)
```

Should be mostly mineunit related (missing `VoxelArea` var)

@S-S-X suggestions? i haven't looked into it but how much work would it be to implement the `VoxelArea` function in  mineunit?