### PR TITLE
Recipe enhancements

### DIFF
--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -17,8 +17,6 @@ local recipes = {
 	{"default:copper_ingot 7",        "default:tin_ingot",          "default:bronze_ingot 8", 12},
 	{"technic:wrought_iron_dust 2",   "technic:coal_dust",          "technic:carbon_steel_dust 2", 6},
 	{"technic:wrought_iron_ingot 2",  "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},
-	{"technic:carbon_steel_dust 2",   "technic:coal_dust",          "technic:cast_iron_dust 2", 6},
-	{"technic:carbon_steel_ingot 2",  "technic:coal_dust",          "technic:cast_iron_ingot 2", 6},
 	{"technic:carbon_steel_dust 4",   "technic:chromium_dust",      "technic:stainless_steel_dust 5", 7.5},
 	{"technic:carbon_steel_ingot 4",  "technic:chromium_ingot",     "technic:stainless_steel_ingot 5", 7.5},
 	{"technic:copper_dust 2",         "technic:zinc_dust",          "technic:brass_dust 3"},

--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -3,6 +3,7 @@ local S = technic.getter
 
 technic.register_recipe_type("alloy", {
 	description = S("Alloying"),
+	icon = "technic_mv_alloy_furnace_front.png",
 	input_size = 2,
 })
 

--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -19,7 +19,7 @@ local recipes = {
 	{"technic:wrought_iron_ingot 2",  "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},
 	{"technic:carbon_steel_dust 4",   "technic:chromium_dust",      "technic:stainless_steel_ingot 5", 7.5},
 	{"technic:carbon_steel_ingot 4",  "technic:chromium_ingot",     "technic:stainless_steel_ingot 5", 7.5},
-	{"technic:copper_dust 2",         "technic:zinc_dust",          "technic:brass_ingot 3"},
+	{"technic:copper_dust 2",         "technic:zinc_dust",          "basic_materials:brass_ingot 3"},
 	{"default:copper_ingot 2",        "technic:zinc_ingot",         "basic_materials:brass_ingot 3"},
 	{"default:sand 2",                "technic:coal_dust 2",        "technic:silicon_wafer"},
 	{"technic:silicon_wafer",         "technic:gold_dust",          "technic:doped_silicon_wafer"},

--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -13,7 +13,7 @@ function technic.register_alloy_recipe(data)
 end
 
 local recipes = {
-	{"technic:copper_dust 7",         "technic:tin_dust",           "technic:bronze_ingot 8", 12},
+	{"technic:copper_dust 7",         "technic:tin_dust",           "default:bronze_ingot 8", 12},
 	{"default:copper_ingot 7",        "default:tin_ingot",          "default:bronze_ingot 8", 12},
 	{"technic:wrought_iron_dust 2",   "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},
 	{"technic:wrought_iron_ingot 2",  "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},

--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -13,13 +13,13 @@ function technic.register_alloy_recipe(data)
 end
 
 local recipes = {
-	{"technic:copper_dust 7",         "technic:tin_dust",           "technic:bronze_dust 8", 12},
+	{"technic:copper_dust 7",         "technic:tin_dust",           "technic:bronze_ingot 8", 12},
 	{"default:copper_ingot 7",        "default:tin_ingot",          "default:bronze_ingot 8", 12},
-	{"technic:wrought_iron_dust 2",   "technic:coal_dust",          "technic:carbon_steel_dust 2", 6},
+	{"technic:wrought_iron_dust 2",   "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},
 	{"technic:wrought_iron_ingot 2",  "technic:coal_dust",          "technic:carbon_steel_ingot 2", 6},
-	{"technic:carbon_steel_dust 4",   "technic:chromium_dust",      "technic:stainless_steel_dust 5", 7.5},
+	{"technic:carbon_steel_dust 4",   "technic:chromium_dust",      "technic:stainless_steel_ingot 5", 7.5},
 	{"technic:carbon_steel_ingot 4",  "technic:chromium_ingot",     "technic:stainless_steel_ingot 5", 7.5},
-	{"technic:copper_dust 2",         "technic:zinc_dust",          "technic:brass_dust 3"},
+	{"technic:copper_dust 2",         "technic:zinc_dust",          "technic:brass_ingot 3"},
 	{"default:copper_ingot 2",        "technic:zinc_ingot",         "basic_materials:brass_ingot 3"},
 	{"default:sand 2",                "technic:coal_dust 2",        "technic:silicon_wafer"},
 	{"technic:silicon_wafer",         "technic:gold_dust",          "technic:doped_silicon_wafer"},

--- a/technic/machines/register/centrifuge_recipes.lua
+++ b/technic/machines/register/centrifuge_recipes.lua
@@ -2,7 +2,8 @@ local S = technic.getter
 
 technic.register_recipe_type("separating", {
 	description = S("Separating"),
-	output_size = 2,
+	icon = "technic_mv_centrifuge_front.png",
+	output_size = 4,
 })
 
 function technic.register_separating_recipe(data)

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -1,7 +1,10 @@
 
 local S = technic.getter
 
-technic.register_recipe_type("compressing", { description = S("Compressing") })
+technic.register_recipe_type("compressing", {
+	description = S("Compressing"),
+	icon = "technic_hv_compressor_front.png",
+})
 
 function technic.register_compressor_recipe(data)
 	data.time = data.time or 4

--- a/technic/machines/register/extractor_recipes.lua
+++ b/technic/machines/register/extractor_recipes.lua
@@ -1,7 +1,10 @@
 
 local S = technic.getter
 
-technic.register_recipe_type("extracting", { description = S("Extracting") })
+technic.register_recipe_type("extracting", {
+	description = S("Extracting"),
+	icon = "technic_mv_extractor_front.png",
+})
 
 function technic.register_extractor_recipe(data)
 	data.time = data.time or 4

--- a/technic/machines/register/freezer_recipes.lua
+++ b/technic/machines/register/freezer_recipes.lua
@@ -1,7 +1,10 @@
 
 local S = technic.getter
 
-technic.register_recipe_type("freezing", { description = S("Freezing") })
+technic.register_recipe_type("freezing", {
+	description = S("Freezing"),
+	icon = "technic_mv_freezer_front.png",
+})
 
 function technic.register_freezer_recipe(data)
 	data.time = data.time or 5

--- a/technic/machines/register/grinder_recipes.lua
+++ b/technic/machines/register/grinder_recipes.lua
@@ -1,7 +1,10 @@
 
 local S = technic.getter
 
-technic.register_recipe_type("grinding", { description = S("Grinding") })
+technic.register_recipe_type("grinding", {
+	description = S("Grinding"),
+	icon = "technic_hv_grinder_front.png",
+})
 
 function technic.register_grinder_recipe(data)
 	data.time = data.time or 3

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -64,6 +64,7 @@ local function register_recipe(typename, data)
 	end
 
 	technic.recipes[typename].recipes[index] = recipe
+	if data.hidden then return end
 	
 	local outputs = type(data.output) == "table" and data.output or {data.output}
 	for _,output in ipairs(outputs) do

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -8,25 +8,23 @@ function technic.register_recipe_type(typename, origdata)
 	for k, v in pairs(origdata) do data[k] = v end
 	data.input_size = data.input_size or 1
 	data.output_size = data.output_size or 1
-	if data.output_size == 1 then
-		if have_ui and unified_inventory.register_craft_type then
-			unified_inventory.register_craft_type(typename, {
-				description = data.description,
-				icon = data.icon,
-				width = data.input_size,
-				height = 1,
-			})
-		end
-		if have_cg and craftguide.register_craft_type then
-			craftguide.register_craft_type(typename, {
-				description = data.description,
-			})
-		end
-		if have_i3 then
-			i3.register_craft_type(typename, {
-				description = data.description,
-			})
-		end
+	if have_ui and unified_inventory.register_craft_type then
+		unified_inventory.register_craft_type(typename, {
+			description = data.description,
+			icon = data.icon,
+			width = data.input_size,
+			height = 1,
+		})
+	end
+	if have_cg and craftguide.register_craft_type then
+		craftguide.register_craft_type(typename, {
+			description = data.description,
+		})
+	end
+	if have_i3 then
+		i3.register_craft_type(typename, {
+			description = data.description,
+		})
 	end
 	data.recipes = {}
 	technic.recipes[typename] = data
@@ -66,32 +64,29 @@ local function register_recipe(typename, data)
 	end
 
 	technic.recipes[typename].recipes[index] = recipe
-	if have_ui and technic.recipes[typename].output_size == 1 then
-		unified_inventory.register_craft({
-			type = typename,
-			output = data.output,
-			items = data.input,
-			width = 0,
-		})
-	end
-	if (have_cg or have_i3) and technic.recipes[typename].output_size == 1 then
-		local result = data.output
-		if (type(result)=="table") then
-			result = result[1]
+	
+	local outputs = type(data.output) == "table" and data.output or {data.output}
+	for _,output in ipairs(outputs) do
+		if have_ui then
+			unified_inventory.register_craft({
+				type = typename,
+				output = output,
+				items = data.input,
+				width = 0,
+			})
 		end
-		local items = table.concat(data.input, ", ")
 		if have_cg and craftguide.register_craft then
 			craftguide.register_craft({
 				type = typename,
-				result = result,
-				items = {items},
+				result = output,
+				items = {table.concat(data.input, ", ")},
 			})
 		end
 		if have_i3 then
 			i3.register_craft({
 				type = typename,
-				result = result,
-				items = {items},
+				result = output,
+				items = {table.concat(data.input, ", ")},
 			})
 		end
 	end

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -12,6 +12,7 @@ function technic.register_recipe_type(typename, origdata)
 		if have_ui and unified_inventory.register_craft_type then
 			unified_inventory.register_craft_type(typename, {
 				description = data.description,
+				icon = data.icon,
 				width = data.input_size,
 				height = 1,
 			})


### PR DESCRIPTION
A few minor, but much needed recipe enhancements:
- Adds centrifuge recipes to the supported craft guides by adding each output separately. This way you can at least find out what can be obtained by centrifuging. Also works for any other recipe type with multiple outputs.
- Adds support for hiding individual recipes. This is useful when there are multiple similar variations. (e.g. beehive centrifuging)
- Adds icons for recipe types in `unified_inventory`. Purely cosmetic.
- Removes the weird and expensive carbon steel to cast iron alloying recipes. The recipes don't make sense and a few players have complained about this.

Example of chernobylite dust centrifuging recipe:

![image](https://github.com/mt-mods/technic/assets/48543043/53dfb6b0-bc5c-4429-ae10-646cdc518a8c)

![image](https://github.com/mt-mods/technic/assets/48543043/5652d535-71bf-4670-9aca-dab5351d4696)
