### PR TITLE
Quarry y-offset and fixes

### DIFF
--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -471,6 +471,7 @@ minetest.register_node("technic:quarry", {
 		meta:set_int("offset_y", 0)
 		meta:set_int("offset_z", 0)
 		meta:set_int("max_depth", quarry_max_depth)
+		meta:set_string("mesecons", "false")
 		meta:get_inventory():set_size("cache", 12)
 		reset_quarry(meta)
 		update_formspec(meta)


### PR DESCRIPTION
A few little improvements to the quarry:
- Adds an option to set the y-offset of the quarry's digging area. This only adjust the top of the digging area, the depth is unaffected.
- Adds an option to restart the quarry when it is moved by a jumpdrive. Default off, but on for existing quarries.
- Sets the mesecons control to be disabled by default. Existing quarries are unaffected by this.
- Added ability to set offset with a vector via digilines. Also adds the offset vector to the table returned by a GET command.

![image](https://github.com/mt-mods/technic/assets/48543043/d9b2f2f1-3573-4517-9c46-eec0d1bddded)

Fixes #297, fixes #312