### PR TITLE
technic:motor to basic_materials:motor

### DIFF
--- a/technic/machines/MV/freezer.lua
+++ b/technic/machines/MV/freezer.lua
@@ -4,7 +4,7 @@ local S = technic.getter
 minetest.register_craft({
 	output = 'technic:mv_freezer',
 	recipe = {
-		{'technic:stainless_steel_ingot', 'technic:motor',          'technic:stainless_steel_ingot'},
+		{'technic:stainless_steel_ingot', 'basic_materials:motor',          'technic:stainless_steel_ingot'},
 		{'pipeworks:pipe_1_empty',        'technic:mv_transformer', 'pipeworks:pipe_1_empty'},
 		{'technic:stainless_steel_ingot', 'technic:mv_cable',       'technic:stainless_steel_ingot'},
 	}


### PR DESCRIPTION
technic:motor does not exist, technic requires basic_materials, [which adds the alias technic:motor to basic_materials:motor](https://github.com/mt-mods/basic_materials/blob/e4a122dfdd991f5a3af27c9a84418fddf22fad49/aliases.lua#L13)

basic_materials:motor is used in other crafts