### PR TITLE
Add ExchangeClone support.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,7 +29,7 @@ read_globals = {
 	"drawers", "mg",
 	"craftguide", "i3", "mtt",
 	"vizlib", "mcl_sounds", "mcl_vars",
-	"mcl_worlds",
+	"mcl_worlds", "exchangeclone",
 
 	-- Only used in technic/machines/MV/lighting.lua (disabled)
 	"isprotect", "homedecor_expect_infinite_stacks",

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -96,8 +96,9 @@ local function register_recipe(typename, data)
 	end
 end
 
--- Checks for "zzzz_exchangeclone_crafthook" mod so that it won't crash with older versions of ExchangeClone which don't have it.
-local has_exchangeclone = minetest.get_modpath("zzzz_exchangeclone_crafthook")
+-- Checks for "zzzz_exchangeclone_crafthook" mod so that it won't crash with older versions of ExchangeClone
+-- which don't have it.
+local has_exchangeclone = minetest.get_modpath("zzzz_exchangeclone_init")
 
 function technic.register_recipe(typename, data)
 	if has_exchangeclone then

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -96,7 +96,8 @@ local function register_recipe(typename, data)
 	end
 end
 
-local has_exchangeclone = minetest.get_modpath("exchangeclone")
+-- Checks for "zzzz_exchangeclone_crafthook" mod so that it won't crash with older versions of ExchangeClone which don't have it.
+local has_exchangeclone = minetest.get_modpath("zzzz_exchangeclone_crafthook")
 
 function technic.register_recipe(typename, data)
 	if has_exchangeclone then

--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -96,7 +96,12 @@ local function register_recipe(typename, data)
 	end
 end
 
+local has_exchangeclone = minetest.get_modpath("exchangeclone")
+
 function technic.register_recipe(typename, data)
+	if has_exchangeclone then
+		exchangeclone.register_technic_recipe(typename, data)
+	end
 	minetest.after(0.01, register_recipe, typename, data) -- Handle aliases
 end
 

--- a/technic/mod.conf
+++ b/technic/mod.conf
@@ -1,3 +1,3 @@
 name = technic
 depends = default, pipeworks, technic_worldgen, basic_materials, moreores
-optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, dye, craftguide, i3, mtt, vizlib, zzzz_exchangeclone_crafthook
+optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, dye, craftguide, i3, mtt, vizlib, zzzz_exchangeclone_init

--- a/technic/mod.conf
+++ b/technic/mod.conf
@@ -1,3 +1,3 @@
 name = technic
 depends = default, pipeworks, technic_worldgen, basic_materials, moreores
-optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, dye, craftguide, i3, mtt, vizlib
+optional_depends = bucket, mesecons, mesecons_mvps, digilines, digiline_remote, unified_inventory, dye, craftguide, i3, mtt, vizlib, zzzz_exchangeclone_crafthook


### PR DESCRIPTION
My mod [ExchangeClone](https://github.com/thepython10110/exchangeclone) calculates an energy value for every item based on crafting recipes. I thought it would be a good idea for it to be able to use Technic's crafting methods, but I discovered that the way Technic waits until everything was loaded before populating `technic.recipes` made that difficult. This is an incredibly simple addition that calls a function every time a recipe is registered.

I have tested with and without ExchangeClone enabled. I doubt it could possibly mess anything up.

In case you're wondering, `zzzz_exchangeclone_crafthook` is named the way it is because Minetest loads mods in reverse alphabetical order.

The function this calls can be found [here](https://github.com/ThePython10110/ExchangeClone/blob/dev/zzzz_exchangeclone_crafthook/init.lua) in the dev branch.