### PR TITLE
Check fuel inventory is empty before digging machine

### DIFF
--- a/technic/machines/register/common.lua
+++ b/technic/machines/register/common.lua
@@ -120,7 +120,7 @@ end
 function technic.machine_can_dig(pos, player)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
-	if not inv:is_empty("src") or not inv:is_empty("dst") then
+	if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("fuel") then
 		if player then
 			minetest.chat_send_player(player:get_player_name(),
 				S("Machine cannot be removed because it is not empty"))


### PR DESCRIPTION
Starting a PR because it's required but it seems trivial to me (as indicated by @OgelGames in [this](https://github.com/mt-mods/technic/issues/284#issuecomment-1255052920) comment).

I tested, it also works with machines which does not have fuel inventory.