### PR TITLE
Fix cable plate placing on several-blocks nodes

### DIFF
--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -96,6 +96,13 @@ function technic.register_cable_plate(nodename, data)
 		def.node_box["connect_"..notconnects[i]] = nil
 		if i == 1 then
 			def.on_place = function(itemstack, placer, pointed_thing)
+				local count = 0
+				for axis in pairs(xyz) do
+					count = count + (pointed_thing.under[axis] == pointed_thing.above[axis] and 0 or 1)
+					if count > 1 then
+						return itemstack
+					end
+				end
 				local pointed_thing_diff = vector.direction(pointed_thing.under, pointed_thing.above)
 				local index = pointed_thing_diff.x + (pointed_thing_diff.y*2) + (pointed_thing_diff.z*3)
 				local num = index < 0 and -index + 3 or index

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -104,6 +104,7 @@ function technic.register_cable_plate(nodename, data)
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 					fine_pointed = vector.subtract(fine_pointed, pointed_thing.above)
 					index = index < 0 and -index or index
+					-- Normalize direction to prevent `xyz` index overflow with oversize nodes
 					index = (index-1)%3+1
 					fine_pointed[xyz[index]] = nil
 					local key_a, a = next(fine_pointed)

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -103,8 +103,9 @@ function technic.register_cable_plate(nodename, data)
 				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) and index ~= 0 then
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 					fine_pointed = vector.subtract(fine_pointed, pointed_thing.above)
+					index = index < 0 and -index or index
 					index = (index-1)%3+1
-					fine_pointed[xyz[index < 0 and -index or index]] = nil
+					fine_pointed[xyz[index]] = nil
 					local key_a, a = next(fine_pointed)
 					local key_b, b = next(fine_pointed, key_a)
 					local far_key = math.abs(a) > math.abs(b) and key_a or key_b

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -103,9 +103,7 @@ function technic.register_cable_plate(nodename, data)
 				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) and index ~= 0 then
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 					fine_pointed = vector.direction(pointed_thing.above,fine_pointed)
-					-- Normalize direction to prevent `xyz` index overflow with oversize nodes
-					index = (math.abs(index)-1)%3+1
-					fine_pointed[xyz[index]] = nil
+					fine_pointed[xyz[index < 0 and -index or index]] = nil
 					local key_a, a = next(fine_pointed)
 					local key_b, b = next(fine_pointed, key_a)
 					local far_key = math.abs(a) > math.abs(b) and key_a or key_b

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -103,6 +103,7 @@ function technic.register_cable_plate(nodename, data)
 				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) and index ~= 0 then
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 					fine_pointed = vector.subtract(fine_pointed, pointed_thing.above)
+					index = (index-1)%3+1
 					fine_pointed[xyz[index < 0 and -index or index]] = nil
 					local key_a, a = next(fine_pointed)
 					local key_b, b = next(fine_pointed, key_a)

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -96,16 +96,15 @@ function technic.register_cable_plate(nodename, data)
 		def.node_box["connect_"..notconnects[i]] = nil
 		if i == 1 then
 			def.on_place = function(itemstack, placer, pointed_thing)
-				local pointed_thing_diff = vector.subtract(pointed_thing.above, pointed_thing.under)
+				local pointed_thing_diff = vector.direction(pointed_thing.under, pointed_thing.above)
 				local index = pointed_thing_diff.x + (pointed_thing_diff.y*2) + (pointed_thing_diff.z*3)
 				local num = index < 0 and -index + 3 or index
 				local crtl = placer:get_player_control()
 				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) and index ~= 0 then
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
-					fine_pointed = vector.subtract(fine_pointed, pointed_thing.above)
-					index = index < 0 and -index or index
+					fine_pointed = vector.direction(pointed_thing.above,fine_pointed)
 					-- Normalize direction to prevent `xyz` index overflow with oversize nodes
-					index = (index-1)%3+1
+					index = (math.abs(index)-1)%3+1
 					fine_pointed[xyz[index]] = nil
 					local key_a, a = next(fine_pointed)
 					local key_b, b = next(fine_pointed, key_a)


### PR DESCRIPTION
The description is not very well because it's hard to describe what I've done in a single, notably in English. I can force-push to a better commit message if needed. EDIT : I think the title describe better the changes now.

What I've done : 
* I noticed by debugging with `minetest.chat_send_all` that the `index` value was exceeding the range of #xyz, so it caused `nil` index in `fine_pointed` call.
* So I just add "brought back" the `index` value within the range of 3 divisors. Lua starts numbering at `1`, so it does that weird `(index-1)%3+1`

Fix #305 