### PR TITLE
add `fakelib` to mtt dependencies

### DIFF
--- a/.github/workflows/mtt.yml
+++ b/.github/workflows/mtt.yml
@@ -11,5 +11,6 @@ jobs:
         git_dependencies: |
           https://github.com/mt-mods/basic_materials.git
           https://github.com/mt-mods/pipeworks.git
+          https://github.com/OgelGames/fakelib.git
           https://github.com/minetest-mods/moreores.git
           https://github.com/mt-mods/xcompat.git


### PR DESCRIPTION
adds the new fakelib-dependency for the tests, see issue in https://github.com/mt-mods/technic/pull/360#issuecomment-2147030365

 (i wish we had a proper cdb-cli for things like that :/)