### PR TITLE
Replace removed function `pipeworks.string_startswith`

### DIFF
--- a/technic_cnc/pipeworks.lua
+++ b/technic_cnc/pipeworks.lua
@@ -42,7 +42,7 @@ end
 local function on_receive_fields(pos, meta, fields, sender, update_formspec)
 	-- https://github.com/mt-mods/pipeworks/-/blob/master/common.lua#L115
 	for field,_ in pairs(fields) do
-		if pipeworks.string_startswith(field, "fs_helpers_cycling:") then
+		if string.sub(field, 1, 19) == "fs_helpers_cycling:" then
 			if pipeworks.may_configure(pos, sender) then
 				pipeworks_on_receive_fields(pos, fields)
 				update_formspec(meta)

--- a/technic_cnc/pipeworks.lua
+++ b/technic_cnc/pipeworks.lua
@@ -42,7 +42,7 @@ end
 local function on_receive_fields(pos, meta, fields, sender, update_formspec)
 	-- https://github.com/mt-mods/pipeworks/-/blob/master/common.lua#L115
 	for field,_ in pairs(fields) do
-		if string.sub(field, 1, 19) == "fs_helpers_cycling:" then
+		if field:match("^fs_helpers_cycling:") then
 			if pipeworks.may_configure(pos, sender) then
 				pipeworks_on_receive_fields(pos, fields)
 				update_formspec(meta)


### PR DESCRIPTION
This fixes the following error:

```
~/.minetest/mods/technic/technic_cnc/pipeworks.lua:45: attempt to call field 'string_startswith' (a nil value)
stack traceback:
	[C]: in function 'string_startswith'
	~/.minetest/mods/technic/technic_cnc/pipeworks.lua:45: in function 'pipeworks_on_receive_fields'
	~/.minetest/mods/technic/technic_cnc/api.lua:367: in function <~/.minetest/mods/technic/technic_cnc/api.lua:363>
```

This PR is ready for review.