### PR TITLE
Allow disabling steel->iron overrides

### DIFF
--- a/technic_worldgen/config.lua
+++ b/technic_worldgen/config.lua
@@ -6,6 +6,7 @@ local defaults = {
 	enable_granite_generation = "true",
 	enable_marble_generation = "true",
 	enable_rubber_tree_generation = "true",
+	enable_steel_override = "true",
 }
 
 for k, v in pairs(defaults) do

--- a/technic_worldgen/init.lua
+++ b/technic_worldgen/init.lua
@@ -15,7 +15,7 @@ dofile(modpath.."/config.lua")
 dofile(modpath.."/nodes.lua")
 dofile(modpath.."/oregen.lua")
 dofile(modpath.."/crafts.lua")
-if minetest.get_modpath("default") then
+if minetest.get_modpath("default") and technic.config:get_bool("enable_steel_override") then
 	dofile(modpath.."/overrides.lua")
 end
 


### PR DESCRIPTION
In some cases it is desirable to have the names and textures of items registered by other mods left alone, even if it comes at the expense of them no longer fitting particularly well with technic.

This PR simply adds a setting to technic.conf (called "enable_steel_override" to fit in with the others) that, when set to false, skips over the entire overrides.lua file. The default is true, which retains the existing behavior.