### PR TITLE
Replace deprecated `ItemStack:get_metadata()` calls

### DIFF
--- a/technic/tools/cans.lua
+++ b/technic/tools/cans.lua
@@ -14,10 +14,10 @@ local function set_can_wear(itemstack, level, max_level)
 end
 
 local function get_can_level(itemstack)
-	if itemstack:get_metadata() == "" then
+	if itemstack:get_meta():get_string("") == "" then
 		return 0
 	else
-		return tonumber(itemstack:get_metadata())
+		return tonumber(itemstack:get_meta():get_string(""))
 	end
 end
 

--- a/technic_chests/digilines.lua
+++ b/technic_chests/digilines.lua
@@ -19,7 +19,7 @@ local function item_matches(item, stack)
 			and (not item.wear or (type(item.wear) == "number" and wear == item.wear) or (type(item.wear) == "table"
 			and (not item.wear[1] or (type(item.wear[1]) == "number" and item.wear[1] <= wear))
 			and (not item.wear[2] or (type(item.wear[2]) == "number" and wear < item.wear[2]))))
-			and (not item.metadata or (type(item.metadata) == "string" and stack:get_metadata() == item.metadata))
+			and (not item.metadata or (type(item.metadata) == "string" and stack:get_meta():get_string("") == item.metadata))
 end
 
 function technic.chests.digiline_effector(pos, _, channel, msg)

--- a/technic_chests/inventory.lua
+++ b/technic_chests/inventory.lua
@@ -20,7 +20,7 @@ function technic.chests.sort_inv(inv, mode)
 			if not stack:is_empty() then
 				local name = stack:get_name()
 				local wear = stack:get_wear()
-				local meta = stack:get_metadata()
+				local meta = stack:get_meta():get_string("")
 				local count = stack:get_count()
 				local def = minetest.registered_items[name]
 				local itemtype = (def and itemtypes[def.type]) and def.type or "none"


### PR DESCRIPTION
Trivial. See https://github.com/minetest/minetest/blob/c4d624083d3a907d73cbb1eb8f6501c6cf268b4d/doc/lua_api.md?plain=1#L7885-L7886