### PR TITLE
Backport tool charge helpers

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,11 +1,10 @@
-on: [push, pull_request]
 name: luacheck
+on: [push, pull_request]
 jobs:
-  lint:
+  luacheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: lint
-        uses: Roang-zero1/factorio-mod-luacheck@master
-        with:
-          luacheckrc_url: ""
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Luacheck
+        uses: lunarmodules/luacheck@master

--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -3,22 +3,21 @@ name: mineunit
 on: [push, pull_request]
 
 jobs:
-  build:
+  mineunit:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
+    - uses: actions/checkout@v3
 
     - id: mineunit
       uses: mt-mods/mineunit-actions@master
       with:
         working-directory: ./technic
+        mineunit-args: --engine-version 5.4.1
         badge-label: Test coverage
 
-    - uses: RubbaBoy/BYOB@v1.2.0
+    - uses: RubbaBoy/BYOB@v1.3.0
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
         NAME: "${{ steps.mineunit.outputs.badge-name }}"
@@ -40,6 +39,7 @@ jobs:
           --------------------------------------------------------------
           ${{ steps.mineunit.outputs.mineunit-report }}
           ```
+          
           ### Raw test runner output for geeks:
           ```
           ${{ steps.mineunit.outputs.mineunit-stdout }}
@@ -53,7 +53,7 @@ jobs:
         comment: |
           <details><summary><i>Mineunit failed regression tests, click for details</i></summary>
           
-          ### Regression test log for technic:
+          ### Regression test log for Technic:
           ```
           ${{ steps.mineunit.outputs.mineunit-stdout }}
           ```

--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -47,6 +47,13 @@ Helper functions
 	* Some configuration function
 * `technic.tube_inject_item(pos, start_pos, velocity, item)`
 	* Same as `pipeworks.tube_inject_item`
+* `technic.get_charge(itemstack)` (alias `technic.get_RE_charge`)
+	* Returns current charge level of tool.
+* `technic.set_charge(itemstack, charge)` (alias `technic.set_RE_charge`)
+	* Sets tool charge level.
+* `technic.use_charge(itemstack, charge)` (alias `technic.use_RE_charge`)
+	* Attempt to use charge and return `true`/`false` indicating success.
+	* Always succeeds without checking charge level if creative is enabled.
 
 Registration functions
 ----------------------

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -77,6 +77,45 @@ function technic.refill_RE_charge(stack)
 	return stack
 end
 
+function technic.set_RE_charge(stack, charge)
+	local max_charge = technic.power_tools[stack:get_name()]
+	if max_charge then
+		technic.set_RE_wear(stack, charge, max_charge)
+		local meta = minetest.deserialize(stack:get_metadata()) or {}
+		meta.charge = math.min(math.max(0, charge), max_charge)
+		stack:set_metadata(minetest.serialize(meta))
+	end
+end
+
+technic.set_charge = technic.set_RE_charge
+
+function technic.get_RE_charge(stack)
+	local max_charge = technic.power_tools[stack:get_name()]
+	if max_charge then
+		local meta = minetest.deserialize(stack:get_metadata()) or {}
+		return meta.charge or 0, max_charge
+	end
+	return 0, 0
+end
+
+technic.get_charge = technic.get_RE_charge
+
+function technic.use_RE_charge(stack, amount)
+	if technic.creative_mode or amount <= 0 then
+		-- Do not check charge in creative mode or when trying to use zero amount
+		return true
+	end
+	local charge = technic.get_RE_charge(stack)
+	if charge < amount then
+		-- Not enough energy available
+		return false
+	end
+	technic.set_RE_charge(stack, charge - amount)
+	-- Charge used successfully
+	return true
+end
+
+technic.use_charge = technic.use_RE_charge
 
 -- If the node is loaded, returns it.  If it isn't loaded, load it and return nil.
 function technic.get_or_load_node(pos)

--- a/technic/spec/fixtures/default.lua
+++ b/technic/spec/fixtures/default.lua
@@ -1,0 +1,32 @@
+mineunit:set_modpath("default", "spec/fixtures")
+
+local function register_node(name, groups, additional_definition)
+	local definition = {
+		description = name.." description",
+		tiles = { "default_"..name },
+		groups = groups,
+	}
+	for k,v in pairs(additional_definition or {}) do definition[k] = v end
+	minetest.register_node(":default:"..name, definition)
+end
+
+local function register_item(name)
+	minetest.register_craftitem(":default:"..name, {
+		description = name.." description",
+	})
+end
+
+-- Register some basic nodes for cutting, grinding, digging, registering recipes etc.
+register_node("stone", {cracky = 3, stone = 1}, {is_ground_content = true, drop = "default:cobble"})
+register_node("cobble", {cracky=3, stone = 2})
+register_node("sand", {snappy=2, choppy=2, oddly_breakable_by_hand=2})
+register_node("wood", {tree=1, choppy=2, oddly_breakable_by_hand=2})
+register_node("dirt", {crumbly = 3, soil = 1})
+register_node("sandstone", {crumbly = 1, cracky = 3})
+register_node("steelblock", {cracky = 1, level = 2})
+register_node("furnace", {cracky=2})
+register_node("furnace_active", {cracky=2, not_in_creative_inventory=1}, {drop = "default:furnace"})
+
+register_item("steel_ingot")
+
+screwdriver = {}

--- a/technic/spec/fixtures/digilines.lua
+++ b/technic/spec/fixtures/digilines.lua
@@ -1,0 +1,36 @@
+-- Simple digilines mod fixture that logs sent messages, works with some simple digiline mods
+
+mineunit:set_modpath("digilines", "spec/fixtures")
+
+digilines = {
+	_msg_log = {},
+	receptor_send = function(pos, rules, channel, msg)
+		table.insert(digilines._msg_log, {
+			pos = pos,
+			rules = rules,
+			channel = channel,
+			msg = msg,
+		})
+	end,
+	rules = {
+		default = {
+			{x=0,  y=0,  z=-1},
+			{x=1,  y=0,  z=0},
+			{x=-1, y=0,  z=0},
+			{x=0,  y=0,  z=1},
+			{x=1,  y=1,  z=0},
+			{x=1,  y=-1, z=0},
+			{x=-1, y=1,  z=0},
+			{x=-1, y=-1, z=0},
+			{x=0,  y=1,  z=1},
+			{x=0,  y=-1, z=1},
+			{x=0,  y=1,  z=-1},
+			{x=0,  y=-1, z=-1}
+		}
+	}
+}
+
+digilines = setmetatable(digilines, {
+	__call = function(self,...) return self end,
+	__index = function(...) return function(...)end end,
+})

--- a/technic/spec/fixtures/mesecons.lua
+++ b/technic/spec/fixtures/mesecons.lua
@@ -1,0 +1,27 @@
+mineunit:set_modpath("mesecons", "spec/fixtures")
+mineunit:set_modpath("mesecons_mvps", "spec/fixtures")
+
+mesecon = {
+	state = {},
+	rules = {
+		default = {
+			{x =  0, y =  0, z = -1},
+			{x =  1, y =  0, z =  0},
+			{x = -1, y =  0, z =  0},
+			{x =  0, y =  0, z =  1},
+			{x =  1, y =  1, z =  0},
+			{x =  1, y = -1, z =  0},
+			{x = -1, y =  1, z =  0},
+			{x = -1, y = -1, z =  0},
+			{x =  0, y =  1, z =  1},
+			{x =  0, y = -1, z =  1},
+			{x =  0, y =  1, z = -1},
+			{x =  0, y = -1, z = -1},
+		}
+	}
+}
+
+mesecon = setmetatable(mesecon, {
+	__call = function(self,...) return self end,
+	__index = function(...) return function(...)end end,
+})

--- a/technic/spec/fixtures/technic.conf
+++ b/technic/spec/fixtures/technic.conf
@@ -1,0 +1,27 @@
+enable_cans = true
+enable_chainsaw = true
+enable_flashlight = true
+enable_mining_drill = true
+enable_mining_laser = true
+enable_multimeter = true
+enable_prospector = true
+enable_sonic_screwdriver = true
+enable_tree_tap = true
+enable_vacuum = true
+
+multimeter_remote_start_ttl = 300
+
+enable_wind_mill = true
+enable_nuclear_reactor_digiline_selfdestruct = true
+quarry_max_depth = 100
+quarry_time_limit = 5000
+
+switch_off_delay_seconds = 1800
+network_overload_reset_time = 20
+admin_priv = basic_privs
+enable_corium_griefing = true
+enable_radiation_protection = true
+enable_radiation_throttling = true
+enable_entity_radiation_damage = true
+enable_longterm_radiation_damage = true
+max_lag_reduction_multiplier = 0.99

--- a/technic/spec/fixtures/technic.lua
+++ b/technic/spec/fixtures/technic.lua
@@ -1,0 +1,22 @@
+-- Use this fixture when loading full Technic mod.
+-- Loads all required modules and fixtures for technic
+
+-- Load modules required by tests
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("common/after")
+mineunit("server")
+mineunit("voxelmanip")
+if mineunit:config("engine_version") ~= "mineunit" then
+	mineunit("game/voxelarea")
+end
+
+-- Load fixtures required by tests
+fixture("default")
+fixture("mesecons")
+fixture("digilines")
+fixture("pipeworks")
+
+-- Load technic_worldgen
+fixture("technic_worldgen")

--- a/technic/spec/fixtures/technic_worldgen.lua
+++ b/technic/spec/fixtures/technic_worldgen.lua
@@ -1,0 +1,7 @@
+-- Load technic_worldgen mod
+
+mineunit:set_modpath("technic_worldgen", "../technic_worldgen")
+
+mineunit:set_current_modname("technic_worldgen")
+sourcefile("../technic_worldgen/init")
+mineunit:restore_current_modname()

--- a/technic/spec/mineunit.conf
+++ b/technic/spec/mineunit.conf
@@ -1,0 +1,11 @@
+deprecated = "ignore"
+time_step = 100
+exclude = {
+	-- Integration tests are not part of mod code
+	"integration_test",
+	-- These are commented out, not part of mod without manually editing code
+	"machines/MV/lighting",
+	"machines/MV/power_radiator",
+	-- Exclude everything outside of technic directory, some are tested but we do not want stats for these
+	"^../"
+}

--- a/technic/spec/tools_spec.lua
+++ b/technic/spec/tools_spec.lua
@@ -1,0 +1,261 @@
+require("mineunit")
+--[[
+	Technic tool regression tests.
+	Execute mineunit at technic source directory.
+--]]
+
+-- Load complete technic mod
+fixture("technic")
+sourcefile("init")
+
+describe("Technic power tool", function()
+
+	world.set_default_node("air")
+
+	-- HV battery box and some HV solar arrays for charging
+	local BB_Charge_POS = {x=0,y=51,z=0}
+	local BB_Discharge_POS = {x=0,y=51,z=2}
+	world.layout({
+		-- Network with generators for charging tools in battery box
+		{BB_Charge_POS, "technic:hv_battery_box0"},
+		{{x=1,y=51,z=0}, "technic:switching_station"},
+		{{{x=2,y=51,z=0},{x=10,y=51,z=0}}, "technic:solar_array_hv"},
+		{{{x=0,y=50,z=0},{x=10,y=50,z=0}}, "technic:hv_cable"},
+		-- Network without generators for discharging tools in battery box
+		{BB_Discharge_POS, "technic:hv_battery_box0"},
+		{{x=1,y=51,z=2}, "technic:switching_station"},
+		{{{x=0,y=50,z=2},{x=1,y=50,z=2}}, "technic:hv_cable"},
+	})
+
+	-- Some helpers to make stack access simpler
+	local player = Player("SX")
+	local charge_inv = minetest.get_meta(BB_Charge_POS):get_inventory()
+	local discharge_inv = minetest.get_meta(BB_Discharge_POS):get_inventory()
+	local function set_charge_stack(stack) charge_inv:set_stack("src", 1, stack) end
+	local function get_charge_stack() return charge_inv:get_stack("src", 1) end
+	local function set_discharge_stack(stack) discharge_inv:set_stack("dst", 1, stack) end
+	local function get_discharge_stack() return discharge_inv:get_stack("dst", 1) end
+	local function set_player_stack(stack) return player:get_inventory():set_stack("main", 1, stack) end
+	local function get_player_stack() return player:get_inventory():get_stack("main", 1) end
+
+	-- Execute on mods loaded callbacks to finish loading.
+	mineunit:mods_loaded()
+	-- Tell mods that 1 minute passed already to execute all weird minetest.after hacks.
+	mineunit:execute_globalstep(60)
+
+	describe("API", function()
+
+		local TOOLNAME = "mymod:powertool1"
+
+		setup(function()
+			set_charge_stack(ItemStack(nil))
+			set_discharge_stack(ItemStack(nil))
+			mineunit:set_current_modname("mymod")
+			mineunit:execute_on_joinplayer(player)
+		end)
+
+		teardown(function()
+			mineunit:execute_on_leaveplayer(player)
+			mineunit:restore_current_modname()
+		end)
+
+		local use_RE_charge_result
+
+		it("technic.register_power_tool works", function()
+			core.register_item(TOOLNAME, {
+				type = "tool",
+				description = "My Mod Power Tool",
+				inventory_image = "mymod_powertool.png",
+				wear_represents = "technic_RE_charge",
+				on_use = function(itemstack, player, pointed_thing)
+					use_RE_charge_result = technic.use_RE_charge(itemstack, 123)
+					return itemstack
+				end,
+			})
+			technic.power_tools[TOOLNAME] = 1234
+			local itemdef = minetest.registered_items[TOOLNAME]
+			assert.is_hashed(itemdef)
+		end)
+
+		it("technic.use_RE_charge works (zero charge)", function()
+			local stack = ItemStack(TOOLNAME)
+			local use_RE_charge_result = technic.use_RE_charge(stack, 123)
+			assert.equals("boolean", type(use_RE_charge_result))
+			assert.is_false(use_RE_charge_result)
+		end)
+
+		it("technic.get_RE_charge works (zero charge)", function()
+			local stack = ItemStack(TOOLNAME)
+			local charge, max_charge = technic.get_RE_charge(stack)
+			assert.equals(0, charge)
+			assert.equals(1234, max_charge)
+		end)
+
+		it("technic.set_RE_charge works (zero charge -> 123)", function()
+			local stack = ItemStack(TOOLNAME)
+			technic.set_RE_charge(stack, 123)
+			assert.equals(123, technic.get_RE_charge(stack))
+		end)
+
+		it("technic.use_RE_charge works (minimum charge)", function()
+			-- Add partially charged tool to player inventory
+			local stack = ItemStack(TOOLNAME)
+			technic.set_RE_charge(stack, 123)
+			set_player_stack(stack)
+
+			-- Use tool and verify results
+			spy.on(technic, "use_RE_charge")
+			player:do_use(player:get_pos())
+			assert.spy(technic.use_RE_charge).called(1)
+			assert.equals("boolean", type(use_RE_charge_result))
+			assert.is_true(use_RE_charge_result)
+			assert.equals(0, technic.get_RE_charge(get_player_stack()))
+		end)
+
+		it("technic.use_RE_charge works (minimum charge + 1)", function()
+			-- Add partially charged tool to player inventory
+			local stack = ItemStack(TOOLNAME)
+			technic.set_RE_charge(stack, 124)
+			set_player_stack(stack)
+			-- Use tool and verify results
+			player:do_use(player:get_pos())
+			assert.equals(1, technic.get_RE_charge(get_player_stack()))
+		end)
+
+	end)
+
+	describe("Flashlight", function()
+
+		local itemname = "technic:flashlight"
+		local itemdef = minetest.registered_items[itemname]
+
+		setup(function()
+			set_charge_stack(ItemStack(nil))
+			set_discharge_stack(ItemStack(nil))
+			mineunit:execute_on_joinplayer(player)
+		end)
+
+		teardown(function()
+			mineunit:execute_on_leaveplayer(player)
+		end)
+
+		it("is registered", function()
+			assert.is_hashed(itemdef)
+			assert.is_function(itemdef.on_refill)
+			assert.equals("technic_RE_charge", itemdef.wear_represents)
+			assert.is_number(technic.power_tools[itemname])
+			assert.gt(technic.power_tools[itemname], 0)
+		end)
+
+		it("charge is used", function()
+			-- Get fully charged item
+			local stack = ItemStack(itemname)
+			technic.set_RE_charge(stack, technic.power_tools[itemname])
+			set_player_stack(stack)
+
+			-- Use item, flashlight charge is used every globalstep and there's no on_use definition
+			for i=1, 100 do
+				mineunit:execute_globalstep(1)
+			end
+
+			-- Check that item charge was actually used and error is acceptable
+			local charge_used = technic.power_tools[itemname] - technic.get_RE_charge(get_player_stack())
+			local exact_use = 2 * 100 -- 2 per cycle / 100 cycles
+			assert.lt(0.9, charge_used / exact_use)
+			assert.gt(1.1, charge_used / exact_use)
+		end)
+
+	end)
+
+	describe("battery box", function()
+
+		local TOOLNAME = "mymod:powertool2"
+		local count_technic_get_charge
+		local count_technic_set_charge
+
+		setup(function()
+			mineunit:set_current_modname("mymod")
+			core.register_item(TOOLNAME, {
+				type = "tool",
+				description = "My Mod Power Tool",
+				inventory_image = "mymod_powertool.png",
+				wear_represents = "technic_RE_charge",
+				technic_get_charge = function(itemstack)
+					assert.is_ItemStack(itemstack)
+					count_technic_get_charge = count_technic_get_charge + 1
+					return technic.get_charge(itemstack)
+				end,
+				technic_set_charge = function(itemstack, charge)
+					assert.is_ItemStack(itemstack)
+					assert.is_number(charge)
+					count_technic_set_charge = count_technic_set_charge + 1
+					return technic.set_charge(itemstack, charge)
+				end,
+				on_use = function(itemstack, player, pointed_thing)
+					use_RE_charge_result = technic.use_RE_charge(itemstack, 123)
+					return itemstack
+				end,
+			})
+			technic.power_tools[TOOLNAME] = 100000
+			mineunit:restore_current_modname()
+			mineunit:execute_on_joinplayer(player)
+		end)
+
+		teardown(function()
+			mineunit:execute_on_leaveplayer(player)
+		end)
+
+		before_each(function()
+			set_charge_stack(ItemStack(nil))
+			set_discharge_stack(ItemStack(nil))
+			count_technic_get_charge = 0
+			count_technic_set_charge = 0
+		end)
+
+		local use_RE_charge_result
+
+		it("registered test tool", function()
+			local itemdef = minetest.registered_items[TOOLNAME]
+			assert.is_hashed(itemdef)
+		end)
+
+		it("discharges tool", function()
+			-- Add partially charged tool to player inventory
+			local stack = ItemStack(TOOLNAME)
+			technic.set_RE_charge(stack, 100000)
+			set_discharge_stack(stack)
+			-- First discharge step, 60k charge (discharge step is 40k/each)
+			mineunit:execute_globalstep(1)
+			assert.equals(60000, technic.get_RE_charge(get_discharge_stack()))
+			-- Second discharge steps, 20k charge
+			mineunit:execute_globalstep(1)
+			assert.equals(20000, technic.get_RE_charge(get_discharge_stack()))
+			-- Last discharge step, no charge
+			mineunit:execute_globalstep(1)
+			assert.equals(0, technic.get_RE_charge(get_discharge_stack()))
+			-- technic.get_RE_charge does not currently use technic_get_charge
+			assert.equals(count_technic_get_charge, 3)
+			assert.equals(count_technic_set_charge, 3)
+		end)
+
+		it("charges tool", function()
+			-- Add partially charged tool to player inventory
+			local stack = ItemStack(TOOLNAME)
+			set_charge_stack(stack)
+			-- First charge step, 10k charge (charge step is 10k/each)
+			mineunit:execute_globalstep(1)
+			assert.equals(10000, technic.get_RE_charge(get_charge_stack()))
+			-- Eight charge steps, 90k charge
+			for i = 1, 8 do mineunit:execute_globalstep(1) end
+			assert.equals(90000, technic.get_RE_charge(get_charge_stack()))
+			-- Last charge step, full charge
+			mineunit:execute_globalstep(1)
+			assert.equals(100000, technic.get_RE_charge(get_charge_stack()))
+			-- technic.get_RE_charge does not currently use technic_get_charge
+			assert.equals(count_technic_get_charge, 10)
+			assert.equals(count_technic_set_charge, 10)
+		end)
+
+	end)
+
+end)


### PR DESCRIPTION
Base branch 1.2.x is selected just for sane comparison.

This PR _**backports following features**_ from (atow) master branch to current 1.2.2 stable release:
* `technic.get_RE_charge(itemstack)`
	* Returns current charge level of tool.
* `technic.set_RE_charge(itemstack, charge)`
	* Sets tool charge level.
* `technic.use_RE_charge(itemstack, charge)`
	* Attempt to use charge and return `true`/`false` indicating success.
	* Always succeeds without checking charge level if creative is enabled.

Aliases  that are _**not in Technic Plus Beta**_ but lately added to original Technic, happily had same interface as above stuff:
* technic.get_charge 
* technic.set_charge

Tool definition:
* `<tooldef>.technic_get_charge(stack)`.
* `<tooldef>.technic_set_charge(stack, charge)`.

### Additions

* technic.use_charge alias for consistency, see #392

### But why?

Mostly because following PR shows that we're bit too far behind with 1.2.x and 2.x would be a fairly big leap forward, there's version specific code for three versions (and this change would allow dropping one of those):
* https://github.com/mt-historical/bweapons_modpack/pull/1

~~Not~~ **included** simple things that ~~could be easily~~ have been backported for compatibility would be at least following tool def functions (just copypasta from master docs):
* For tool charger mods it is recommended to use `<tooldef>.technic_get_charge(stack)` instead.
* For tool charger mods it is recommended to use `<tooldef>.technic_set_charge(stack, charge)` instead.

## This probably should not be merged but instead
in case this gets approved it should make a new release branch, tag and cdb release.
Though in case someone argues this is a bug fix then yeah, 1.2.3 would be fine too.