### PR TITLE
Coal alloy furnace ABM: tolerate broken metadata

### DIFF
--- a/technic/machines/other/coal_alloy_furnace.lua
+++ b/technic/machines/other/coal_alloy_furnace.lua
@@ -107,12 +107,10 @@ minetest.register_abm({
 	chance = 1,
 	action = function(pos, node, active_object_count, active_object_count_wider)
 		local meta = minetest.get_meta(pos)
-		local inv    = meta:get_inventory()
-
-		if inv:get_size("src") == 1 then -- Old furnace -> convert it
-			inv:set_size("src", 2)
-			inv:set_stack("src", 2, inv:get_stack("src2", 1))
-			inv:set_size("src2", 0)
+		local inv = meta:get_inventory()
+		local src_list = inv:get_list("src")
+		if not src_list then
+			return
 		end
 
 		for i, name in pairs({
@@ -126,7 +124,7 @@ minetest.register_abm({
 		end
 
 		-- Get what to cook if anything
-		local recipe = technic.get_recipe("alloy", inv:get_list("src"))
+		local recipe = technic.get_recipe("alloy", src_list)
 
 		local was_active = false
 
@@ -150,32 +148,32 @@ minetest.register_abm({
 			meta:set_string("infotext", S("@1 Active", machine_name).." ("..percent.."%)")
 			technic.swap_node(pos, "technic:coal_alloy_furnace_active")
 			meta:set_string("formspec",
-					size..
-					"label[0,0;"..machine_name.."]"..
-					"image[2,2;1,1;default_furnace_fire_bg.png^[lowpart:"..
-					(100 - percent)..":default_furnace_fire_fg.png]"..
-					"list[context;fuel;2,3;1,1;]"..
-					"list[context;src;2,1;2,1;]"..
-					"list[context;dst;5,1;2,2;]"..
+				size..
+				"label[0,0;"..machine_name.."]"..
+				"image[2,2;1,1;default_furnace_fire_bg.png^[lowpart:"..
+				(100 - percent)..":default_furnace_fire_fg.png]"..
+				"list[context;fuel;2,3;1,1;]"..
+				"list[context;src;2,1;2,1;]"..
+				"list[context;dst;5,1;2,2;]"..
 
-					(minetest.get_modpath("mcl_formspec") and
-						mcl_formspec.get_itemslot_bg(2,3,1,1)..
-						mcl_formspec.get_itemslot_bg(2,1,2,1)..
-						mcl_formspec.get_itemslot_bg(5,1,2,2)..
-						-- player inventory
-						"list[current_player;main;0,4.5;9,3;9]"..
-						mcl_formspec.get_itemslot_bg(0,4.5,9,3)..
-						"list[current_player;main;0,7.74;9,1;]"..
-						mcl_formspec.get_itemslot_bg(0,7.74,9,1)
-					or "list[current_player;main;0,5;8,4;]")..
+				(minetest.get_modpath("mcl_formspec") and
+					mcl_formspec.get_itemslot_bg(2,3,1,1)..
+					mcl_formspec.get_itemslot_bg(2,1,2,1)..
+					mcl_formspec.get_itemslot_bg(5,1,2,2)..
+					-- player inventory
+					"list[current_player;main;0,4.5;9,3;9]"..
+					mcl_formspec.get_itemslot_bg(0,4.5,9,3)..
+					"list[current_player;main;0,7.74;9,1;]"..
+					mcl_formspec.get_itemslot_bg(0,7.74,9,1)
+				or "list[current_player;main;0,5;8,4;]")..
 
-					-- listrings
-					"listring[context;dst]"..
-					"listring[current_player;main]"..
-					"listring[context;src]"..
-					"listring[current_player;main]"..
-					"listring[context;fuel]"..
-					"listring[current_player;main]")
+				-- listrings
+				"listring[context;dst]"..
+				"listring[current_player;main]"..
+				"listring[context;src]"..
+				"listring[current_player;main]"..
+				"listring[context;fuel]"..
+				"listring[current_player;main]")
 			return
 		end
 
@@ -189,13 +187,8 @@ minetest.register_abm({
 		end
 
 		-- Next take a hard look at the fuel situation
-		local fuel = nil
-		local afterfuel
 		local fuellist = inv:get_list("fuel")
-
-		if fuellist then
-			fuel, afterfuel = minetest.get_craft_result({method = "fuel", width = 1, items = fuellist})
-		end
+		local fuel, afterfuel = minetest.get_craft_result({method = "fuel", width = 1, items = fuellist})
 
 		if fuel.time <= 0 then
 			meta:set_string("infotext", S("@1 Out Of Fuel", machine_name))


### PR DESCRIPTION
Closes #398 

For API `technic.get_recipe(method, items)` I'd rather leave it as is and not try to check every possible user mistake there but rather specify that arguments must be of correct type and contain correct information.

This old compatibility shim has been there for over 11 years already and now it has been removed.
Additionally we've already dropped some similar compatibility shims that were not even this old.
```lua
		if inv:get_size("src") == 1 then -- Old furnace -> convert it
			inv:set_size("src", 2)
			inv:set_stack("src", 2, inv:get_stack("src2", 1))
			inv:set_size("src2", 0)
		end
```

Fixes:
```
Failure → spec/other_spec.lua @ 45
  Coal alloy furnace wont crash without placement callbacks
  spec/other_spec.lua:48: Expected no error, but caught:
```