### PR TITLE
MTG compatible screwdriver API

### DIFF
--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -62,6 +62,14 @@ function technic.swap_node(pos, name)
 	end
 end
 
+-- MTG compatible screwdriver API nodedef.on_rotate compatibility
+function technic.on_rotate(pos, node, user, mode, new_param2)
+	node.param2 = new_param2
+	minetest.swap_node(pos, node)
+	pipeworks.scan_for_tube_objects(pos)
+	return true
+end
+
 function technic.set_charge(stack, charge)
 	local wear_factor = stack:get_definition().technic_wear_factor
 	if wear_factor then

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -582,6 +582,7 @@ minetest.register_node("technic:quarry", {
 			action = digiline_action,
 		}
 	},
+	on_rotate = technic.on_rotate,
 })
 
 minetest.register_craft({

--- a/technic/machines/MV/tool_workshop.lua
+++ b/technic/machines/MV/tool_workshop.lua
@@ -145,7 +145,8 @@ minetest.register_node("technic:tool_workshop", {
 	},
 	technic_run = run,
 	after_place_node = pipeworks.after_place,
-	after_dig_node = technic.machine_after_dig_node
+	after_dig_node = technic.machine_after_dig_node,
+	on_rotate = technic.on_rotate,
 })
 
 technic.register_machine("MV", "technic:tool_workshop", technic.receiver)

--- a/technic/machines/other/coal_alloy_furnace.lua
+++ b/technic/machines/other/coal_alloy_furnace.lua
@@ -75,6 +75,7 @@ minetest.register_node("technic:coal_alloy_furnace", {
 	on_metadata_inventory_move = technic.machine_on_inventory_move,
 	on_metadata_inventory_put = technic.machine_on_inventory_put,
 	on_metadata_inventory_take = technic.machine_on_inventory_take,
+	on_rotate = technic.on_rotate,
 })
 
 minetest.register_node("technic:coal_alloy_furnace_active", {
@@ -98,6 +99,7 @@ minetest.register_node("technic:coal_alloy_furnace_active", {
 	on_metadata_inventory_move = technic.machine_on_inventory_move,
 	on_metadata_inventory_put = technic.machine_on_inventory_put,
 	on_metadata_inventory_take = technic.machine_on_inventory_take,
+	on_rotate = technic.on_rotate,
 })
 
 minetest.register_abm({

--- a/technic/machines/register/generator.lua
+++ b/technic/machines/register/generator.lua
@@ -193,6 +193,7 @@ function technic.register_generator(data)
 			local percent = math.floor(burn_time / burn_totaltime * 100)
 			update_generator_formspec(meta, desc, percent, form_buttons)
 		end,
+		on_rotate = technic.on_rotate,
 	})
 
 	minetest.register_node("technic:"..ltier.."_generator_active", {
@@ -286,6 +287,7 @@ function technic.register_generator(data)
 
 			update_generator_formspec(meta, desc, percent, form_buttons)
 		end,
+		on_rotate = technic.on_rotate,
 	})
 
 	technic.register_machine(tier, "technic:"..ltier.."_generator",        technic.producer)

--- a/technic/machines/register/machine_base.lua
+++ b/technic/machines/register/machine_base.lua
@@ -239,6 +239,7 @@ function technic.register_base_machine(nodename, data)
 			end
 			meta:set_string("formspec", formspec..form_buttons)
 		end,
+		on_rotate = technic.on_rotate,
 	})
 
 	minetest.register_node(colon..nodename.."_active",{
@@ -290,6 +291,7 @@ function technic.register_base_machine(nodename, data)
 			end
 			meta:set_string("formspec", formspec..form_buttons)
 		end,
+		on_rotate = technic.on_rotate,
 	})
 
 	technic.register_machine(tier, nodename,            technic.receiver)


### PR DESCRIPTION
Rebase to master before merging.

Closes #404 and #267
Alternative to #368 

Preview: adds generic on_rotate function for machines which in turn improves generic screwdriver compatibility.
Not just MTG but any of the screwedriver mods compatible with MTG.

If concept gets approved I'll work on it a bit more, some machines would like to get some other related fixes and some should be handled a bit different ways although nothing really big there.