### PR TITLE
Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Technic
 
 A mod for [minetest](http://www.minetest.net)
 
-![mtt](https://github.com/mt-mods/technic/workflows/mtt/badge.svg)
-![luacheck](https://github.com/mt-mods/technic/workflows/luacheck/badge.svg)
-![mineunit](https://github.com/mt-mods/technic/workflows/mineunit/badge.svg)
+[![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
+[![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
+[![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
 ![](https://byob.yarr.is/mt-mods/technic/coverage)
 
 [![License](https://img.shields.io/badge/license-LGPLv2.0%2B-purple.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A mod for [minetest](http://www.minetest.net)
 [![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
 [![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
 [![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
-![](https://byob.yarr.is/mt-mods/technic/coverage)
+[![mineunit](https://byob.yarr.is/mt-mods/technic/coverage)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)
 
 [![License](https://img.shields.io/badge/license-LGPLv2.0%2B-purple.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html)
 [![ContentDB](https://content.minetest.net/packages/mt-mods/technic_plus/shields/downloads/)](https://content.minetest.net/packages/mt-mods/technic_plus/)

--- a/technic_chests/README.md
+++ b/technic_chests/README.md
@@ -1,9 +1,9 @@
 Technic chests
 ==============
 
-![luacheck](https://github.com/mt-mods/technic/workflows/luacheck/badge.svg)
-![mineunit](https://github.com/mt-mods/technic/workflows/mineunit/badge.svg)
-![](https://byob.yarr.is/mt-mods/technic/coverage-chests)
+[![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
+[![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
+[![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-chests)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)
 
 License
 -------

--- a/technic_chests/README.md
+++ b/technic_chests/README.md
@@ -1,7 +1,6 @@
 Technic chests
 ==============
 
-[![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
 [![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
 [![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
 [![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-chests)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)

--- a/technic_chests/README.md
+++ b/technic_chests/README.md
@@ -1,6 +1,7 @@
 Technic chests
 ==============
 
+[![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
 [![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
 [![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
 [![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-chests)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)

--- a/technic_cnc/README.md
+++ b/technic_cnc/README.md
@@ -3,7 +3,6 @@ Technic CNC
 
 Provides CNC machines that allow cutting nodes to selected shapes.
 
-[![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
 [![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
 [![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
 [![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-cnc)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)

--- a/technic_cnc/README.md
+++ b/technic_cnc/README.md
@@ -3,9 +3,9 @@ Technic CNC
 
 Provides CNC machines that allow cutting nodes to selected shapes.
 
-![luacheck](https://github.com/mt-mods/technic/workflows/luacheck/badge.svg)
-![mineunit](https://github.com/mt-mods/technic/workflows/mineunit/badge.svg)
-![](https://byob.yarr.is/mt-mods/technic/coverage-cnc)
+[![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
+[![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
+[![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-cnc)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)
 
 # Machines
 

--- a/technic_cnc/README.md
+++ b/technic_cnc/README.md
@@ -3,6 +3,7 @@ Technic CNC
 
 Provides CNC machines that allow cutting nodes to selected shapes.
 
+[![mtt](https://github.com/mt-mods/technic/actions/workflows/mtt.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mtt.yml?query=branch%3Amaster)
 [![luacheck](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/luacheck.yml?query=branch%3Amaster)
 [![mineunit](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml/badge.svg)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster)
 [![mineunit](https://byob.yarr.is/mt-mods/technic/coverage-cnc)](https://github.com/mt-mods/technic/actions/workflows/mineunit.yml?query=branch%3Amaster+is%3Asuccess)


### PR DESCRIPTION
Badges for _mtt_, _luacheck_ and _mineunit_ in README.md are showing status from latest run without taking branch into account.

Statuses should only come from main release branch which is master (or _default_ where it can be used).

Also linked badges in a way that makes it easy to find actual latest report for the master branch.

Report for most current workflow execution, where badge actually comes from, will be the very first entry instead of being hidden somewhere below development/bugfix/pending pull requests/etc.