### PR TITLE
Correct ejection side for param2=1&3

### DIFF
--- a/technic/machines/register/common.lua
+++ b/technic/machines/register/common.lua
@@ -97,9 +97,9 @@ function technic.handle_machine_pipeworks(pos, tube_upgrade, send_function)
 	local z_velocity = 0
 
 	-- Output is on the left side of the furnace
-	if node.param2 == 3 then pos1.z = pos1.z - 1  z_velocity = -1 end
+	if node.param2 == 3 then pos1.z = pos1.z + 1  z_velocity =  1 end
 	if node.param2 == 2 then pos1.x = pos1.x - 1  x_velocity = -1 end
-	if node.param2 == 1 then pos1.z = pos1.z + 1  z_velocity =  1 end
+	if node.param2 == 1 then pos1.z = pos1.z - 1  z_velocity = -1 end
 	if node.param2 == 0 then pos1.x = pos1.x + 1  x_velocity =  1 end
 
 	local output_tube_connected = false


### PR DESCRIPTION
Machines should always eject to their right, regardless of rotation.
Prior to this patch that was incorrect depending on the rotation of the machine, with param2 == 1 or 3 machines ejecting to the left.
This may break existing setups that have already accounted for this quirk, but IMO it's better to be consistent.
May or may not have been relevant: #336