### PR TITLE
Fix check for `unifieddyes`

### DIFF
--- a/extranodes/init.lua
+++ b/extranodes/init.lua
@@ -1,7 +1,7 @@
 -- Minetest 0.4.6 mod: extranodes
 -- namespace: technic
 
-if unifieddyes and not unifieddyes.preserve_metadata then
+if core.get_modpath("unifieddyes") and not unifieddyes.preserve_metadata then
 	error("Incompatible version of unifieddyes found. Please update it to the latest version.")
 end
 


### PR DESCRIPTION
Fixes this warning:
```
WARNING[ServerStart]: Undeclared global variable "unifieddyes" accessed at ..\technic\extranodes\init.lua:4
```